### PR TITLE
feat(bin): 0 exit code when no unused rules found

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -29,6 +29,8 @@ Object.keys(options).forEach(function findRules(option) {
     if (rules.length) {
       console.log('\n' + options[option][0], 'rules\n') // eslint-disable-line no-console
       console.log(rules.join(', ')) // eslint-disable-line no-console
+    } else if (option === 'getUnusedRules') {
+      processExitCode = 0
     }
   }
 })

--- a/test/bin.js
+++ b/test/bin.js
@@ -67,6 +67,16 @@ describe('bin', function() {
     assert.ok(getUnusedRules.called)
   })
 
+  it('options -u|--unused and no unused rules found', function() {
+    getUnusedRules.returns([])
+    process.exit = function(status) {
+      assert.equal(status, 0)
+    }
+    process.argv[2] = '-u'
+    proxyquire('../src/bin', stub)
+    assert.ok(getUnusedRules.called)
+  })
+
   it('option -u|--unused along with -n|no-error', function() {
     process.exit = function(status) {
       assert.equal(status, 0)


### PR DESCRIPTION
Before, no unused rules always returned a non-zero exit code even when
no unused rules were found. Now, -u only returns a non-zero exit code
when an unused rule is found.

This makes eslint-find-rules an even better tool by being able to
be ran on CI when ESLint updates for configs.