### PR TITLE
chore(ci-build): Make travis-after-all npm scrit to run serially

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check-coverage": "nyc check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "report-coverage": "cat ./coverage/lcov.info | node_modules/.bin/codecov",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-    "travis-after-all": "travis-after-all && (npm run report-coverage & npm run semantic-release)"
+    "travis-after-all": "travis-after-all && npm run report-coverage && npm run semantic-release"
   },
   "bin": {
     "eslint-find-rules": "src/bin/find.js",


### PR DESCRIPTION
Ensure to complete report-coverage script to complete, even if semantic-release fails.

(#35 is the last PR including a Coverage Report as post in the discussion)
