### PR TITLE
fix(lib): Diff of array should consider both sides

### DIFF
--- a/src/lib/array-diff.js
+++ b/src/lib/array-diff.js
@@ -2,18 +2,30 @@ function difference(a, b) {
   var hash = {}
   var diff = {}
 
-  b.forEach(function createHash(item) {
-    hash[item] = true
-  })
+  b.forEach(createHash(hash))
+  a.forEach(findDiff(hash, diff))
 
-  a.forEach(function findDiff(item) {
-    if (!hash[item] && !diff[item]) {
-      diff[item] = true
-    }
-  })
+  // return the other way round
+  hash = {}
+  a.forEach(createHash(hash))
+  b.forEach(findDiff(hash, diff))
 
   return Object.keys(diff)
 
+}
+
+function createHash(hash) {
+  return function curried(item) {
+    hash[item] = true
+  }
+}
+
+function findDiff(hash, diff) {
+  return function curried(item) {
+    if (!hash[item] && !diff[item]) {
+      diff[item] = true
+    }
+  }
 }
 
 module.exports = difference

--- a/test/lib/array-diff.js
+++ b/test/lib/array-diff.js
@@ -5,15 +5,15 @@ describe('difference', function() {
   it('should return difference', function() {
     assert.deepEqual(
       difference(['a', 'b', 'c'], ['x', 'y', 'z']),
-      ['a', 'b', 'c']
+      ['a', 'b', 'c', 'x', 'y', 'z']
     )
     assert.deepEqual(
       difference(['a', 'b', 'c'], ['a', 'y', 'z']),
-      ['b', 'c']
+      ['b', 'c', 'y', 'z']
     )
     assert.deepEqual(
       difference(['a', 'b', 'c'], ['a', 'b', 'z']),
-      ['c']
+      ['c', 'z']
     )
 
     assert.deepEqual(
@@ -22,4 +22,3 @@ describe('difference', function() {
     )
   })
 })
-


### PR DESCRIPTION
At the moment, `lib/array-diff.js` in my opinion return an erroneous diff:

```JavaScript
//          "a"           , "b"
difference(['a', 'b', 'c'], ['a', 'y', 'z']) == ['b', 'c']
```

It should also take those elements of array `b` not present in array `a` into account:
```JavaScript
//          "a"           , "b"
difference(['a', 'b', 'c'], ['a', 'y', 'z']) == ['b', 'c', 'y', 'z']
```