### PR TITLE
Comprehensive config comparison & verbose output

### DIFF
--- a/src/bin/diff.js
+++ b/src/bin/diff.js
@@ -2,19 +2,25 @@
 
 'use strict'
 
+var path = require('path')
+
+var argv = require('yargs')
+  .boolean('verbose')
+  .alias('v', 'verbose')
+  .argv
+
 var size = require('window-size')
 var availableWidth = size.width || /* istanbul ignore next */ 80
 var ui = require('cliui')({width: availableWidth})
 
 var getRuleFinder = require('../lib/rule-finder')
-var difference = require('../lib/array-diff')
+var arrayDifference = require('../lib/array-diff')
+var objectDifference = require('../lib/object-diff')
 var getSortedRules = require('../lib/sort-rules')
 
-var rules = getSortedRules(
-  difference(
-    getRuleFinder(process.argv[2]).getCurrentRules(),
-    getRuleFinder(process.argv[3]).getCurrentRules()
-  )
+var rules = rulesDifference(
+  getRuleFinder(argv._[0]),
+  getRuleFinder(argv._[1])
 )
 
 var outputRules, outputRuleCellMapper
@@ -22,21 +28,50 @@ var outputPadding = ' '
 var outputMaxWidth = 0
 var outputMaxCols = 0
 
+argv.verbose && console.log( // eslint-disable-line no-console
+  '\ndiff rules\n' + rules.length + ' rules found\n'
+)
 /* istanbul ignore next */
 if (rules.length) {
-  console.log('\n diff rules\n') // eslint-disable-line no-console
+  if (argv.verbose) {
+    rules = [].concat.apply([], rules)
+    rules.unshift('', path.basename(argv._[0]), path.basename(argv._[1]))
+  } else {
+    console.log('\ndiff rules\n') // eslint-disable-line no-console
+  }
   rules = rules.map(function columnSpecification(rule) {
-    rule = rule + outputPadding
+    if (typeof rule !== 'string') {
+      rule = JSON.stringify(rule)
+    }
+    rule += outputPadding
     outputMaxWidth = Math.max(rule.length, outputMaxWidth)
     return rule
   })
-  outputMaxCols = Math.floor(availableWidth / outputMaxWidth)
+  outputMaxCols = argv.verbose ? 3 : Math.floor(availableWidth / outputMaxWidth)
   outputRuleCellMapper = getOutputRuleCellMapper(Math.floor(availableWidth / outputMaxCols))
   while (rules.length) {
     outputRules = rules.splice(0, outputMaxCols).map(outputRuleCellMapper)
     ui.div.apply(ui, outputRules)
   }
   console.log(ui.toString()) // eslint-disable-line no-console
+}
+
+function rulesDifference(a, b) {
+  if (argv.verbose) {
+    return getSortedRules(
+      objectDifference(
+        a.getCurrentRulesDetailed(),
+        b.getCurrentRulesDetailed()
+      )
+    )
+  }
+
+  return getSortedRules(
+    arrayDifference(
+      a.getCurrentRules(),
+      b.getCurrentRules()
+    )
+  )
 }
 
 function getOutputRuleCellMapper(width) {

--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -7,6 +7,7 @@ var options = {
   getPluginRules: ['plugin', 'p'],
   getAllAvailableRules: ['all-available', 'a'],
   getUnusedRules: ['unused', 'u'],
+  verbose: ['verbose', 'v'],
   n: ['no-error'],
 }
 
@@ -32,9 +33,12 @@ Object.keys(options).forEach(function findRules(option) {
   var ruleFinderMethod = ruleFinder[option]
   if (argv[option] && ruleFinderMethod) {
     rules = ruleFinderMethod()
+    argv.verbose && console.log( // eslint-disable-line no-console
+      '\n' + options[option][0] + ' rules\n' + rules.length + ' rules found\n'
+    )
     /* istanbul ignore next */
     if (rules.length) {
-      console.log('\n' + options[option][0], 'rules\n') // eslint-disable-line no-console
+      !argv.verbose && console.log('\n' + options[option][0] + ' rules\n') // eslint-disable-line no-console
       rules = rules.map(function columnSpecification(rule) {
         rule = rule + outputPadding
         outputMaxWidth = Math.max(rule.length, outputMaxWidth)

--- a/src/lib/object-diff.js
+++ b/src/lib/object-diff.js
@@ -1,0 +1,26 @@
+var assert = require('assert')
+
+function difference(a, b) {
+  var hash = {}
+  var diff = []
+
+  Object.keys(a).forEach(compare(hash, diff, a, b))
+  Object.keys(b).forEach(compare(hash, diff, a, b))
+
+  return diff
+}
+
+function compare(hash, diff, a, b) {
+  return function curriedf(n) {
+    if (!hash[n]) {
+      hash[n] = true
+      try {
+        assert.deepEqual(a[n], b[n])
+      } catch (e) {
+        diff.push([n, a[n], b[n]])
+      }
+    }
+  }
+}
+
+module.exports = difference

--- a/src/lib/rule-finder.js
+++ b/src/lib/rule-finder.js
@@ -75,6 +75,11 @@ function RuleFinder(specifiedFile) {
     return getSortedRules(currentRules)
   }
 
+  // get all the current rules' particular configuration
+  this.getCurrentRulesDetailed = function getCurrentRulesDetailed() {
+    return config.rules
+  }
+
   // get all the plugin rules instead of referring the extended files or documentation
   this.getPluginRules = function getPluginRules() {
     return getSortedRules(pluginRules)

--- a/src/lib/sort-rules.js
+++ b/src/lib/sort-rules.js
@@ -2,7 +2,17 @@
 
 function getSortedRules(rules) {
   return rules.sort(function sort(a, b) {
-    return a > b ? 1 : -1
+    var first, second
+
+    if (typeof a === 'string' && typeof b === 'string') {
+      first = a
+      second = b
+    } else {
+      first = a[0]
+      second = b[0]
+    }
+
+    return first > second ? 1 : -1
   })
 }
 

--- a/test/bin/diff.js
+++ b/test/bin/diff.js
@@ -4,15 +4,18 @@ var sinon = require('sinon')
 
 var consoleLog = console.log // eslint-disable-line no-console
 
-var difference = sinon.stub().returns(['diff'])
+var arrayDifference = sinon.stub().returns(['diff'])
+var objectDifference = sinon.stub().returns(['diff'])
 
 var stub = {
   '../lib/rule-finder': function() {
     return {
       getCurrentRules: function noop() {},
+      getCurrentRulesDetailed: function noop() {},
     }
   },
-  '../lib/array-diff': difference,
+  '../lib/array-diff': arrayDifference,
+  '../lib/object-diff': objectDifference,
 }
 
 describe('diff', function() {
@@ -23,6 +26,8 @@ describe('diff', function() {
 
   afterEach(function() {
     console.log = consoleLog // eslint-disable-line no-console
+    // purge yargs cache
+    delete require.cache[require.resolve('yargs')]
   })
 
   it('log diff', function() {
@@ -35,6 +40,20 @@ describe('diff', function() {
       consoleLog.apply(null, arguments)
     }
     proxyquire('../../src/bin/diff', stub)
-    assert.ok(difference.called)
+    assert.ok(arrayDifference.called)
+  })
+
+  it('verbose log diff', function() {
+    process.argv[2] = './foo'
+    process.argv[3] = './bar'
+    process.argv[4] = '-v'
+    console.log = function() { // eslint-disable-line no-console
+      if (arguments[0].match(/(diff)/)) {
+        return
+      }
+      consoleLog.apply(null, arguments)
+    }
+    proxyquire('../../src/bin/diff', stub)
+    assert.ok(objectDifference.called)
   })
 })

--- a/test/bin/find.js
+++ b/test/bin/find.js
@@ -86,4 +86,17 @@ describe('bin', function() {
     proxyquire('../../src/bin/find', stub)
     assert.ok(getUnusedRules.called)
   })
+
+  it('verbose log', function() {
+    console.log = function() { // eslint-disable-line no-console
+      if (arguments[0].match(/(current)/) && arguments[0].match(/(rules found)/)) {
+        return
+      }
+      consoleLog.apply(null, arguments)
+    }
+    process.argv[2] = '-c'
+    process.argv[3] = '--verbose'
+    proxyquire('../../src/bin/find', stub)
+    assert.ok(getCurrentRules.called)
+  })
 })

--- a/test/lib/array-diff.js
+++ b/test/lib/array-diff.js
@@ -1,7 +1,7 @@
 var assert = require('assert')
 var difference = require('../../src/lib/array-diff')
 
-describe('difference', function() {
+describe('array difference', function() {
   it('should return difference', function() {
     assert.deepEqual(
       difference(['a', 'b', 'c'], ['x', 'y', 'z']),
@@ -22,4 +22,3 @@ describe('difference', function() {
     )
   })
 })
-

--- a/test/lib/object-diff.js
+++ b/test/lib/object-diff.js
@@ -1,0 +1,24 @@
+var assert = require('assert')
+var difference = require('../../src/lib/object-diff')
+
+describe('object difference', function() {
+  it('should return difference', function() {
+    assert.deepEqual(
+      difference({a: ['a', 'b', 'c']}, {a: ['x', 'y', 'z']}),
+      [['a', ['a', 'b', 'c'], ['x', 'y', 'z']]]
+    )
+    assert.deepEqual(
+      difference({a: ['a', 'b', 'c']}, {a: 'a'}),
+      [['a', ['a', 'b', 'c'], 'a']]
+    )
+    assert.deepEqual(
+      difference({a: ['a', 'b', 'c']}, {b: ['a', 'b', 'c']}),
+      [['a', ['a', 'b', 'c'], undefined], ['b', undefined, ['a', 'b', 'c']]]
+    )
+
+    assert.deepEqual(
+      difference({a: ['a', 'b', 'c']}, {a: ['a', 'b', 'c']}),
+      []
+    )
+  })
+})

--- a/test/lib/rule-finder.js
+++ b/test/lib/rule-finder.js
@@ -39,13 +39,22 @@ describe('rule-finder', function() {
     assert.deepEqual(ruleFinder.getUnusedRules(), ['bar-rule', 'baz-rule'])
   })
 
-  it('no specifiedFile - curent rules', function() {
+  it('no specifiedFile - current rules', function() {
     var ruleFinder
     process.cwd = function() {
       return noSpecifiedFile
     }
     ruleFinder = getRuleFinder()
     assert.deepEqual(ruleFinder.getCurrentRules(), ['foo-rule'])
+  })
+
+  it('no specifiedFile - current rule config', function() {
+    var ruleFinder
+    process.cwd = function() {
+      return noSpecifiedFile
+    }
+    ruleFinder = getRuleFinder()
+    assert.deepEqual(ruleFinder.getCurrentRulesDetailed(), {'foo-rule': [2]})
   })
 
   it('no specifiedFile - plugin rules', function() {
@@ -71,9 +80,14 @@ describe('rule-finder', function() {
     assert.deepEqual(ruleFinder.getUnusedRules(), ['baz-rule', 'react/bar-rule', 'react/baz-rule', 'react/foo-rule'])
   })
 
-  it('specifiedFile (relative path) - curent rules', function() {
+  it('specifiedFile (relative path) - current rules', function() {
     var ruleFinder = getRuleFinder(specifiedFileRelative)
     assert.deepEqual(ruleFinder.getCurrentRules(), ['bar-rule', 'foo-rule'])
+  })
+
+  it('specifiedFile (relative path) - current rule config', function() {
+    var ruleFinder = getRuleFinder(specifiedFileRelative)
+    assert.deepEqual(ruleFinder.getCurrentRulesDetailed(), {'bar-rule': [2], 'foo-rule': [2]})
   })
 
   it('specifiedFile (relative path) - plugin rules', function() {
@@ -94,9 +108,14 @@ describe('rule-finder', function() {
     assert.deepEqual(ruleFinder.getUnusedRules(), ['baz-rule', 'react/bar-rule', 'react/baz-rule', 'react/foo-rule'])
   })
 
-  it('specifiedFile (absolut path) - curent rules', function() {
+  it('specifiedFile (absolut path) - current rules', function() {
     var ruleFinder = getRuleFinder(specifiedFileAbsolute)
     assert.deepEqual(ruleFinder.getCurrentRules(), ['bar-rule', 'foo-rule'])
+  })
+
+  it('specifiedFile (absolut path) - current rule config', function() {
+    var ruleFinder = getRuleFinder(specifiedFileAbsolute)
+    assert.deepEqual(ruleFinder.getCurrentRulesDetailed(), {'foo-rule': [2], 'bar-rule': [2]})
   })
 
   it('specifiedFile (absolut path) - plugin rules', function() {

--- a/test/lib/sort-rules.js
+++ b/test/lib/sort-rules.js
@@ -16,4 +16,15 @@ describe('sort-rules', function() {
       ['a', 'aa', 'ab', 'b', 'c']
     )
   })
+
+  it('should return sorted rule configs', function() {
+    assert.deepEqual(
+      sortRules([['a', ['b', 'c'], ['d', 'e']], ['b', ['c', 'd'], ['e', 'f']]]),
+      [['a', ['b', 'c'], ['d', 'e']], ['b', ['c', 'd'], ['e', 'f']]]
+    )
+    assert.deepEqual(
+      sortRules([['c', ['d', 'e'], ['f', 'g']], ['b', ['c'], 'd'], ['a', ['b', 'c'], undefined]]),
+      [['a', ['b', 'c'], undefined], ['b', ['c'], 'd'], ['c', ['d', 'e'], ['f', 'g']]]
+    )
+  })
 })


### PR DESCRIPTION
When using with eslint-diff-rules, the actual configuration is compared and printed when
specifying option `-v|--verbose`. When using with `eslint-find-rules`, the output is extended by the actual number of found rules (even when 0 rules have been found).

Closes #6. Closes #7.