### PR TITLE
3/3: Verbose Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ var ruleFinder = getRuleFinder('path/to/eslint-config')
 
 ruleFinder.getCurrentRules()
 
+ruleFinder.getCurrentRulesDetailed()
+
 ruleFinder.getPluginRules()
 
 ruleFinder.getAllAvailableRules()

--- a/src/bin/diff.js
+++ b/src/bin/diff.js
@@ -2,41 +2,74 @@
 
 'use strict'
 
+var path = require('path')
+
 var size = require('window-size')
 var availableWidth = size.width || /* istanbul ignore next */ 80
 var ui = require('cliui')({width: availableWidth})
 
 var getRuleFinder = require('../lib/rule-finder')
-var difference = require('../lib/array-diff')
+var arrayDifference = require('../lib/array-diff')
 var getSortedRules = require('../lib/sort-rules')
 
-var rules = getSortedRules(
-  difference(
-    getRuleFinder(process.argv[2]).getCurrentRules(),
-    getRuleFinder(process.argv[3]).getCurrentRules()
-  )
-)
-
-var outputRules, outputRuleCellMapper
 var outputPadding = ' '
 var outputMaxWidth = 0
 var outputMaxCols = 0
 
-/* istanbul ignore next */
-if (rules.length) {
-  console.log('\n diff rules\n') // eslint-disable-line no-console
-  rules = rules.map(function columnSpecification(rule) {
-    rule = rule + outputPadding
-    outputMaxWidth = Math.max(rule.length, outputMaxWidth)
-    return rule
+var files = [process.argv[2], process.argv[3]]
+var collectedRules = [files, [].concat(files).reverse()].map(
+  function diffConfigs(currentFiles) {
+    var rules = getSortedRules(
+      arrayDifference(
+        getRuleFinder(currentFiles[0]).getCurrentRules(),
+        getRuleFinder(currentFiles[1]).getCurrentRules()
+      )
+    ).map(function columnSpecification(rule) {
+      rule = rule + outputPadding
+      outputMaxWidth = Math.max(rule.length, outputMaxWidth)
+      return rule
+    })
+
+    return {
+      base: path.basename(currentFiles[0]),
+      head: path.basename(currentFiles[1]),
+      rules: rules,
+    }
   })
+
+var rulesCount = collectedRules.reduce(
+  function getLength(prev, curr) {
+    return prev + (curr && curr.rules ? curr.rules.length : /* istanbul ignore next */ 0)
+  }, 0)
+
+var outputRuleCellMapper
+
+/* istanbul ignore next */
+if (rulesCount) {
+  console.log('\ndiff rules') // eslint-disable-line no-console
+
   outputMaxCols = Math.floor(availableWidth / outputMaxWidth)
   outputRuleCellMapper = getOutputRuleCellMapper(Math.floor(availableWidth / outputMaxCols))
-  while (rules.length) {
-    outputRules = rules.splice(0, outputMaxCols).map(outputRuleCellMapper)
-    ui.div.apply(ui, outputRules)
-  }
-  console.log(ui.toString()) // eslint-disable-line no-console
+
+  collectedRules.forEach(function displayConfigs(config) {
+    var rules = config.rules
+
+    if (!rules.length) {
+      return
+    }
+
+    console.log( // eslint-disable-line no-console
+      '\nin ' + config.base + ' but not in ' + config.head + ':\n' +
+      rules.length + ' rules found\n'
+    )
+    while (rules.length) {
+      ui.div.apply(
+        ui,
+        rules.splice(0, outputMaxCols).map(outputRuleCellMapper)
+      )
+    }
+    console.log(ui.toString()) // eslint-disable-line no-console
+  })
 }
 
 function getOutputRuleCellMapper(width) {

--- a/src/bin/diff.js
+++ b/src/bin/diff.js
@@ -3,6 +3,10 @@
 'use strict'
 
 var path = require('path')
+var argv = require('yargs')
+  .boolean('verbose')
+  .alias('v', 'verbose')
+  .argv
 
 var size = require('window-size')
 var availableWidth = size.width || /* istanbul ignore next */ 80
@@ -10,32 +14,15 @@ var ui = require('cliui')({width: availableWidth})
 
 var getRuleFinder = require('../lib/rule-finder')
 var arrayDifference = require('../lib/array-diff')
+var objectDifference = require('../lib/object-diff')
 var getSortedRules = require('../lib/sort-rules')
 
 var outputPadding = ' '
 var outputMaxWidth = 0
 var outputMaxCols = 0
 
-var files = [process.argv[2], process.argv[3]]
-var collectedRules = [files, [].concat(files).reverse()].map(
-  function diffConfigs(currentFiles) {
-    var rules = getSortedRules(
-      arrayDifference(
-        getRuleFinder(currentFiles[0]).getCurrentRules(),
-        getRuleFinder(currentFiles[1]).getCurrentRules()
-      )
-    ).map(function columnSpecification(rule) {
-      rule = rule + outputPadding
-      outputMaxWidth = Math.max(rule.length, outputMaxWidth)
-      return rule
-    })
-
-    return {
-      base: path.basename(currentFiles[0]),
-      head: path.basename(currentFiles[1]),
-      rules: rules,
-    }
-  })
+var files = [argv._[0], argv._[1]]
+var collectedRules = getFilesToCompare(files).map(compareConfigs)
 
 var rulesCount = collectedRules.reduce(
   function getLength(prev, curr) {
@@ -48,7 +35,7 @@ var outputRuleCellMapper
 if (rulesCount) {
   console.log('\ndiff rules') // eslint-disable-line no-console
 
-  outputMaxCols = Math.floor(availableWidth / outputMaxWidth)
+  outputMaxCols = argv.verbose ? 3 : Math.floor(availableWidth / outputMaxWidth)
   outputRuleCellMapper = getOutputRuleCellMapper(Math.floor(availableWidth / outputMaxCols))
 
   collectedRules.forEach(function displayConfigs(config) {
@@ -58,10 +45,15 @@ if (rulesCount) {
       return
     }
 
-    console.log( // eslint-disable-line no-console
-      '\nin ' + config.base + ' but not in ' + config.head + ':\n' +
-      rules.length + ' rules found\n'
-    )
+    if (argv.verbose) {
+      rules.unshift('', config.base, config.head)
+    } else {
+      console.log( // eslint-disable-line no-console
+        '\nin ' + config.base + ' but not in ' + config.head + ':\n' +
+        rules.length + ' rules found\n'
+      )
+    }
+
     while (rules.length) {
       ui.div.apply(
         ui,
@@ -70,6 +62,60 @@ if (rulesCount) {
     }
     console.log(ui.toString()) // eslint-disable-line no-console
   })
+}
+
+function getFilesToCompare(allFiles) {
+  var filesToCompare = [allFiles]
+
+  if (!argv.verbose) {
+    // in non-verbose output mode, compare a to be
+    // and b to a afterwards, to obtain ALL differences
+    // across those files, but grouped
+    filesToCompare.push([].concat(allFiles).reverse())
+  }
+
+  return filesToCompare
+}
+
+function compareConfigs(currentFiles) {
+  var rules = rulesDifference(
+    getRuleFinder(currentFiles[0]),
+    getRuleFinder(currentFiles[1])
+  )
+
+  return {
+    base: path.basename(currentFiles[0]),
+    head: path.basename(currentFiles[1]),
+    rules: rules.map(transformToColumnSpecification),
+  }
+}
+
+function rulesDifference(a, b) {
+  if (argv.verbose) {
+    return getSortedRules(
+      objectDifference(
+        a.getCurrentRulesDetailed(),
+        b.getCurrentRulesDetailed()
+      )
+    )
+  }
+
+  return getSortedRules(
+    arrayDifference(
+      a.getCurrentRules(),
+      b.getCurrentRules()
+    )
+  )
+}
+
+function transformToColumnSpecification(rule) {
+  /* istanbul ignore if */
+  if (typeof rule !== 'string') {
+    rule = JSON.stringify(rule)
+  }
+  rule = rule + outputPadding
+  outputMaxWidth = Math.max(rule.length, outputMaxWidth)
+  return rule
 }
 
 function getOutputRuleCellMapper(width) {

--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -7,6 +7,7 @@ var options = {
   getPluginRules: ['plugin', 'p'],
   getAllAvailableRules: ['all-available', 'a'],
   getUnusedRules: ['unused', 'u'],
+  verbose: ['verbose', 'v'],
   n: ['no-error'],
 }
 
@@ -32,9 +33,12 @@ Object.keys(options).forEach(function findRules(option) {
   var ruleFinderMethod = ruleFinder[option]
   if (argv[option] && ruleFinderMethod) {
     rules = ruleFinderMethod()
+    argv.verbose && console.log( // eslint-disable-line no-console
+      '\n' + options[option][0] + ' rules\n' + rules.length + ' rules found\n'
+    )
     /* istanbul ignore next */
     if (rules.length) {
-      console.log('\n' + options[option][0], 'rules\n') // eslint-disable-line no-console
+      !argv.verbose && console.log('\n' + options[option][0] + ' rules\n') // eslint-disable-line no-console
       rules = rules.map(function columnSpecification(rule) {
         rule = rule + outputPadding
         outputMaxWidth = Math.max(rule.length, outputMaxWidth)

--- a/src/lib/object-diff.js
+++ b/src/lib/object-diff.js
@@ -1,0 +1,27 @@
+var assert = require('assert')
+
+function difference(a, b) {
+  var diff = {}
+
+  Object.keys(a).forEach(compare(diff, a, b))
+  Object.keys(b).forEach(compare(diff, a, b))
+
+  return diff
+}
+
+function compare(diff, a, b) {
+  return function curried(n) {
+    if (!diff[n]) {
+      try {
+        assert.deepEqual(a[n], b[n])
+      } catch (e) {
+        diff[n] = {
+          config1: a[n],
+          config2: b[n],
+        }
+      }
+    }
+  }
+}
+
+module.exports = difference

--- a/src/lib/rule-finder.js
+++ b/src/lib/rule-finder.js
@@ -75,6 +75,11 @@ function RuleFinder(specifiedFile) {
     return getSortedRules(currentRules)
   }
 
+  // get all the current rules' particular configuration
+  this.getCurrentRulesDetailed = function getCurrentRulesDetailed() {
+    return config.rules
+  }
+
   // get all the plugin rules instead of referring the extended files or documentation
   this.getPluginRules = function getPluginRules() {
     return getSortedRules(pluginRules)

--- a/src/lib/sort-rules.js
+++ b/src/lib/sort-rules.js
@@ -1,9 +1,27 @@
 'use strict'
 
 function getSortedRules(rules) {
-  return rules.sort(function sort(a, b) {
-    return a > b ? 1 : -1
-  })
+  return Array.isArray(rules) ? getSortedRulesArray(rules) : transformIntoSortedRulesArray(rules)
+}
+
+function getSortedRulesArray(rules) {
+  return rules.sort(sortAlphabetically)
+}
+
+function transformIntoSortedRulesArray(rules) {
+  var sortedRules = []
+
+  Object.keys(rules)
+    .sort(sortAlphabetically)
+    .forEach(function map(ruleName) {
+      sortedRules.push(ruleName, rules[ruleName].config1, rules[ruleName].config2)
+    })
+
+  return sortedRules
+}
+
+function sortAlphabetically(a, b) {
+  return a > b ? 1 : -1
 }
 
 module.exports = getSortedRules

--- a/test/bin/diff.js
+++ b/test/bin/diff.js
@@ -4,7 +4,7 @@ var sinon = require('sinon')
 
 var consoleLog = console.log // eslint-disable-line no-console
 
-var difference = sinon.stub().returns(['diff'])
+var arrayDifference = sinon.stub().returns(['diff'])
 
 var stub = {
   '../lib/rule-finder': function() {
@@ -12,7 +12,7 @@ var stub = {
       getCurrentRules: function noop() {},
     }
   },
-  '../lib/array-diff': difference,
+  '../lib/array-diff': arrayDifference,
 }
 
 describe('diff', function() {
@@ -29,12 +29,12 @@ describe('diff', function() {
     process.argv[2] = './foo'
     process.argv[3] = './bar'
     console.log = function() { // eslint-disable-line no-console
-      if (arguments[0].match(/(diff)/)) {
+      if (arguments[0].match(/(diff|but not in|rules found)/)) {
         return
       }
       consoleLog.apply(null, arguments)
     }
     proxyquire('../../src/bin/diff', stub)
-    assert.ok(difference.called)
+    assert.ok(arrayDifference.called)
   })
 })

--- a/test/bin/diff.js
+++ b/test/bin/diff.js
@@ -5,14 +5,17 @@ var sinon = require('sinon')
 var consoleLog = console.log // eslint-disable-line no-console
 
 var arrayDifference = sinon.stub().returns(['diff'])
+var objectDifference = sinon.stub().returns(['diff'])
 
 var stub = {
   '../lib/rule-finder': function() {
     return {
       getCurrentRules: function noop() {},
+      getCurrentRulesDetailed: function noop() {},
     }
   },
   '../lib/array-diff': arrayDifference,
+  '../lib/object-diff': objectDifference,
 }
 
 describe('diff', function() {
@@ -23,6 +26,8 @@ describe('diff', function() {
 
   afterEach(function() {
     console.log = consoleLog // eslint-disable-line no-console
+    // purge yargs cache
+    delete require.cache[require.resolve('yargs')]
   })
 
   it('log diff', function() {
@@ -36,5 +41,19 @@ describe('diff', function() {
     }
     proxyquire('../../src/bin/diff', stub)
     assert.ok(arrayDifference.called)
+  })
+
+  it('verbose log diff', function() {
+    process.argv[2] = './foo'
+    process.argv[3] = './bar'
+    process.argv[4] = '-v'
+    console.log = function() { // eslint-disable-line no-console
+      if (arguments[0].match(/(diff)/)) {
+        return
+      }
+      consoleLog.apply(null, arguments)
+    }
+    proxyquire('../../src/bin/diff', stub)
+    assert.ok(objectDifference.called)
   })
 })

--- a/test/bin/find.js
+++ b/test/bin/find.js
@@ -24,7 +24,7 @@ var stub = {
 describe('bin', function() {
   beforeEach(function() {
     console.log = function() { // eslint-disable-line no-console
-      if (arguments[0].match(/(current|plugin|all\-available|unused)/)) {
+      if (arguments[0].match(/(current|plugin|all\-available|unused|rules found)/)) {
         return
       }
       consoleLog.apply(null, arguments)
@@ -88,12 +88,6 @@ describe('bin', function() {
   })
 
   it('verbose log', function() {
-    console.log = function() { // eslint-disable-line no-console
-      if (arguments[0].match(/(current|rules found)/)) {
-        return
-      }
-      consoleLog.apply(null, arguments)
-    }
     process.argv[2] = '-c'
     process.argv[3] = '--verbose'
     proxyquire('../../src/bin/find', stub)

--- a/test/bin/find.js
+++ b/test/bin/find.js
@@ -86,4 +86,17 @@ describe('bin', function() {
     proxyquire('../../src/bin/find', stub)
     assert.ok(getUnusedRules.called)
   })
+
+  it('verbose log', function() {
+    console.log = function() { // eslint-disable-line no-console
+      if (arguments[0].match(/(current|rules found)/)) {
+        return
+      }
+      consoleLog.apply(null, arguments)
+    }
+    process.argv[2] = '-c'
+    process.argv[3] = '--verbose'
+    proxyquire('../../src/bin/find', stub)
+    assert.ok(getCurrentRules.called)
+  })
 })

--- a/test/lib/object-diff.js
+++ b/test/lib/object-diff.js
@@ -1,0 +1,27 @@
+var assert = require('assert')
+var difference = require('../../src/lib/object-diff')
+
+describe('object difference', function() {
+  it('should return difference', function() {
+    assert.deepEqual(
+      difference({'foo-rule': [2, 'foo']}, {'foo-rule': [2, 'bar']}),
+      {'foo-rule': {config1: [2, 'foo'], config2: [2, 'bar']}}
+    )
+    assert.deepEqual(
+      difference({'foo-rule': [2, 'foo', 'bar']}, {'foo-rule': 2}),
+      {'foo-rule': {config1: [2, 'foo', 'bar'], config2: 2}}
+    )
+    assert.deepEqual(
+      difference({'foo-rule': [0, 'foo']}, {'bar-rule': [1, 'bar']}),
+      {
+        'foo-rule': {config1: [0, 'foo'], config2: undefined},
+        'bar-rule': {config1: undefined, config2: [1, 'bar']},
+      }
+    )
+
+    assert.deepEqual(
+      difference({'foo-rule': [1, 'foo', 'bar']}, {'foo-rule': [1, 'foo', 'bar']}),
+      {}
+    )
+  })
+})

--- a/test/lib/rule-finder.js
+++ b/test/lib/rule-finder.js
@@ -48,6 +48,15 @@ describe('rule-finder', function() {
     assert.deepEqual(ruleFinder.getCurrentRules(), ['foo-rule'])
   })
 
+  it('no specifiedFile - current rule config', function() {
+    var ruleFinder
+    process.cwd = function() {
+      return noSpecifiedFile
+    }
+    ruleFinder = getRuleFinder()
+    assert.deepEqual(ruleFinder.getCurrentRulesDetailed(), {'foo-rule': [2]})
+  })
+
   it('no specifiedFile - plugin rules', function() {
     var ruleFinder
     process.cwd = function() {
@@ -76,6 +85,11 @@ describe('rule-finder', function() {
     assert.deepEqual(ruleFinder.getCurrentRules(), ['bar-rule', 'foo-rule'])
   })
 
+  it('specifiedFile (relative path) - current rule config', function() {
+    var ruleFinder = getRuleFinder(specifiedFileRelative)
+    assert.deepEqual(ruleFinder.getCurrentRulesDetailed(), {'bar-rule': [2], 'foo-rule': [2]})
+  })
+
   it('specifiedFile (relative path) - plugin rules', function() {
     var ruleFinder = getRuleFinder(specifiedFileRelative)
     assert.deepEqual(ruleFinder.getPluginRules(), ['react/bar-rule', 'react/baz-rule', 'react/foo-rule'])
@@ -97,6 +111,11 @@ describe('rule-finder', function() {
   it('specifiedFile (absolut path) - curent rules', function() {
     var ruleFinder = getRuleFinder(specifiedFileAbsolute)
     assert.deepEqual(ruleFinder.getCurrentRules(), ['bar-rule', 'foo-rule'])
+  })
+
+  it('specifiedFile (absolut path) - current rule config', function() {
+    var ruleFinder = getRuleFinder(specifiedFileAbsolute)
+    assert.deepEqual(ruleFinder.getCurrentRulesDetailed(), {'foo-rule': [2], 'bar-rule': [2]})
   })
 
   it('specifiedFile (absolut path) - plugin rules', function() {

--- a/test/lib/sort-rules.js
+++ b/test/lib/sort-rules.js
@@ -16,4 +16,15 @@ describe('sort-rules', function() {
       ['a', 'aa', 'ab', 'b', 'c']
     )
   })
+
+  it('should return sorted rule configs', function() {
+    assert.deepEqual(
+      sortRules({'bar-rule': {config1: '1', config2: '2'}, 'baz-rule': {config1: '3', config2: '4'}}),
+      ['bar-rule', '1', '2', 'baz-rule', '3', '4']
+    )
+    assert.deepEqual(
+      sortRules({'foo-rule': {config1: '1', config2: '2'}, 'bar-rule': {config1: '3', config2: '4'}}),
+      ['bar-rule', '3', '4', 'foo-rule', '1', '2']
+    )
+  })
 })


### PR DESCRIPTION
* feat: get current rules detailed config (from PR #49)

* feat(diff): compare both ways
sample output:
![image](https://cloud.githubusercontent.com/assets/262436/14586714/dd0c9840-04a1-11e6-89f4-1c3311173b1e.png)

* feat(find): add verbose output

* feat(diff): add detailed comparison output
sample output:
![image](https://cloud.githubusercontent.com/assets/262436/14586721/f183025a-04a1-11e6-850c-122d44798cdc.png)

I think, a nice extension for the "detailed comparison output" would be colorization:

* **yellow**: loose equality, e.g. `2` and `[2]`
* **orange**: both configs specify the rule, but they different, e.g. `0` and `[2, "always"]`
* **red**: the rule is `undefined` in one of the configs