### PR TITLE
refactor(output): render output via a utility wrapper

### DIFF
--- a/src/bin/diff.js
+++ b/src/bin/diff.js
@@ -2,9 +2,7 @@
 
 'use strict'
 
-var size = require('window-size')
-var availableWidth = size.width || /* istanbul ignore next */ 80
-var ui = require('cliui')({width: availableWidth})
+var cli = require('../lib/cli-util')
 
 var getRuleFinder = require('../lib/rule-finder')
 var difference = require('../lib/array-diff')
@@ -17,30 +15,10 @@ var rules = getSortedRules(
   )
 )
 
-var outputRules, outputRuleCellMapper
-var outputPadding = ' '
-var outputMaxWidth = 0
-var outputMaxCols = 0
-
 /* istanbul ignore next */
 if (rules.length) {
-  console.log('\n diff rules\n') // eslint-disable-line no-console
-  rules = rules.map(function columnSpecification(rule) {
-    rule = rule + outputPadding
-    outputMaxWidth = Math.max(rule.length, outputMaxWidth)
-    return rule
-  })
-  outputMaxCols = Math.floor(availableWidth / outputMaxWidth)
-  outputRuleCellMapper = getOutputRuleCellMapper(Math.floor(availableWidth / outputMaxCols))
-  while (rules.length) {
-    outputRules = rules.splice(0, outputMaxCols).map(outputRuleCellMapper)
-    ui.div.apply(ui, outputRules)
-  }
-  console.log(ui.toString()) // eslint-disable-line no-console
+  cli.push('\ndiff rules\n')
+  cli.push(rules)
 }
 
-function getOutputRuleCellMapper(width) {
-  return function curriedOutputRuleCellMapper(rule) {
-    return {text: rule, width: width}
-  }
-}
+cli.write()

--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -15,9 +15,7 @@ var argv = require('yargs')
   .alias(options)
   .argv
 
-var size = require('window-size')
-var availableWidth = size.width || /* istanbul ignore next */ 80
-var ui = require('cliui')({width: availableWidth})
+var cli = require('../lib/cli-util')
 
 var processExitCode = argv.u && !argv.n ? 1 : 0
 var getRuleFinder = require('../lib/rule-finder')
@@ -25,28 +23,15 @@ var specifiedFile = argv._[0]
 
 var ruleFinder = getRuleFinder(specifiedFile)
 Object.keys(options).forEach(function findRules(option) {
-  var rules, outputRules, outputRuleCellMapper
-  var outputPadding = ' '
-  var outputMaxWidth = 0
-  var outputMaxCols = 0
+  var rules
   var ruleFinderMethod = ruleFinder[option]
   if (argv[option] && ruleFinderMethod) {
     rules = ruleFinderMethod()
     /* istanbul ignore next */
     if (rules.length) {
-      console.log('\n' + options[option][0], 'rules\n') // eslint-disable-line no-console
-      rules = rules.map(function columnSpecification(rule) {
-        rule = rule + outputPadding
-        outputMaxWidth = Math.max(rule.length, outputMaxWidth)
-        return rule
-      })
-      outputMaxCols = Math.floor(availableWidth / outputMaxWidth)
-      outputRuleCellMapper = getOutputRuleCellMapper(Math.floor(availableWidth / outputMaxCols))
-      while (rules.length) {
-        outputRules = rules.splice(0, outputMaxCols).map(outputRuleCellMapper)
-        ui.div.apply(ui, outputRules)
-      }
-      console.log(ui.toString()) // eslint-disable-line no-console
+      cli.push('\n' + options[option][0] + ' rules\n')
+      cli.push(rules)
+      cli.write()
     } else if (option === 'getUnusedRules') {
       processExitCode = 0
     }
@@ -55,10 +40,4 @@ Object.keys(options).forEach(function findRules(option) {
 
 if (processExitCode) {
   process.exit(processExitCode)
-}
-
-function getOutputRuleCellMapper(width) {
-  return function curriedOutputRuleCellMapper(rule) {
-    return {text: rule, width: width}
-  }
 }

--- a/src/lib/cli-util.js
+++ b/src/lib/cli-util.js
@@ -1,0 +1,41 @@
+var size = require('window-size')
+var availableWidth = size.width || /*istanbul ignore next */ 80
+var ui = require('cliui')({width: availableWidth})
+
+function push(output, columns) {
+  var _output = [].concat(output)
+
+  var padding = {top: 0, right: 2, bottom: 0, left: 0}
+  var width = _output.reduce(
+    function getMaxWidth(previous, current) {
+      return Math.max(padding.left + current.length + padding.right, previous)
+    }, 0)
+
+  var _columns = columns || Math.floor(availableWidth / width)
+  var cellMapper = getOutputCellMapper(Math.floor(availableWidth / _columns), padding)
+
+  while (_output.length) {
+    ui.div.apply(ui, _output.splice(0, _columns).map(cellMapper))
+  }
+}
+
+function write(logger) {
+  var _logger = logger || console
+  var _log = _logger.log || /* istanbul ignore next */ console.log // eslint-disable-line no-console
+  _log(ui.toString())
+}
+
+function getOutputCellMapper(width, padding) {
+  return function curriedOutputCellMapper(text) {
+    return {
+      text: text,
+      width: width,
+      padding: [padding.top, padding.right, padding.bottom, padding.left],
+    }
+  }
+}
+
+module.exports = {
+  push: push,
+  write: write,
+}

--- a/test/lib/cli-util.js
+++ b/test/lib/cli-util.js
@@ -1,0 +1,76 @@
+var assert = require('assert')
+var proxyquire = require('proxyquire')
+var sinon = require('sinon')
+
+var moduleStub = {
+  'window-size': {width: 80},
+}
+
+var loggerStub = {
+  log: function noop() {},
+}
+
+describe('cli-util', function() {
+
+  before(function() {
+    sinon.stub(loggerStub, 'log')
+  })
+
+  after(function() {
+    loggerStub.log.restore()
+  })
+
+  it('prints out single lines', function() {
+    var cli = proxyquire('../../src/lib/cli-util', moduleStub)
+
+    cli.push('A single line')
+    cli.write(loggerStub)
+
+    assert.ok(
+      loggerStub.log.calledWith(
+        sinon.match(/^A single line$/)
+      )
+    )
+  })
+
+  it('prints out multiple columns', function() {
+    var cli = proxyquire('../../src/lib/cli-util', moduleStub)
+
+    cli.push([
+      'Everything in a single cell',
+      'Everything in a single cell',
+      'Everything in a single cell',
+      'Everything in a single cell',
+      'Everything in a single cell',
+    ])
+    cli.write(loggerStub)
+
+    assert.ok(
+      loggerStub.log.calledWith(
+        sinon.match(/^(Everything in a single cell\s{13}Everything in a single cell\n){2}Everything in a single cell$/)
+      )
+    )
+  })
+
+  it('prints out with an exact amount of columns', function() {
+    var cli = proxyquire('../../src/lib/cli-util', moduleStub)
+
+    cli.push([
+      'This in the first row',
+      'This in the first row',
+      'This in the first row',
+      'This in the second row',
+      'This in the second row',
+    ], 3)
+    cli.write(loggerStub)
+
+    assert.ok(
+      loggerStub.log.calledWith(
+        sinon.match(
+          /^(This in the first row(\s{5}){0,1}){3}\n(This in the second row(\s{4}){0,1}){2}$/
+        )
+      )
+    )
+  })
+
+})


### PR DESCRIPTION
Creates a utility wrapper for `cliui` and let's `bin/diff` and `bin/find` use it.