### PR TITLE
feat(diff): compare config in both ways

### DIFF
--- a/src/bin/diff.js
+++ b/src/bin/diff.js
@@ -2,23 +2,61 @@
 
 'use strict'
 
+var path = require('path')
+
 var cli = require('../lib/cli-util')
 
 var getRuleFinder = require('../lib/rule-finder')
 var difference = require('../lib/array-diff')
 var getSortedRules = require('../lib/sort-rules')
 
-var rules = getSortedRules(
-  difference(
-    getRuleFinder(process.argv[2]).getCurrentRules(),
-    getRuleFinder(process.argv[3]).getCurrentRules()
-  )
-)
+var files = [process.argv[2], process.argv[3]]
+var collectedRules = getFilesToCompare(files).map(compareConfigs)
+
+var rulesCount = collectedRules.reduce(
+  function getLength(prev, curr) {
+    return prev + (curr && curr.rules ? curr.rules.length : /* istanbul ignore next */ 0)
+  }, 0)
 
 /* istanbul ignore next */
-if (rules.length) {
+if (rulesCount) {
   cli.push('\ndiff rules\n')
-  cli.push(rules)
+  collectedRules.forEach(function displayConfigs(diff) {
+    var rules = diff.rules
+
+    if (!rules.length) {
+      return
+    }
+
+    cli.push('\nin ' + diff.config1 + ' but not in ' + diff.config2 + ':\n')
+    cli.push(rules)
+  })
 }
 
 cli.write()
+
+function getFilesToCompare(allFiles) {
+  var filesToCompare = [allFiles]
+  filesToCompare.push([].concat(allFiles).reverse())
+  return filesToCompare
+}
+
+function compareConfigs(currentFiles) {
+  return {
+    config1: path.basename(currentFiles[0]),
+    config2: path.basename(currentFiles[1]),
+    rules: rulesDifference(
+      getRuleFinder(currentFiles[0]),
+      getRuleFinder(currentFiles[1])
+    ),
+  }
+}
+
+function rulesDifference(a, b) {
+  return getSortedRules(
+    difference(
+      a.getCurrentRules(),
+      b.getCurrentRules()
+    )
+  )
+}


### PR DESCRIPTION
Implements the two way diffing on

```
eslint-diff-rules config1 config2
```

---

This PR still includes its predecessor's commit — so I guess it (again) should be rebased after #58 got merged (why does this not get resolved automatically??) ...