### PR TITLE
feat: Support plugins with scoped names

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -31,6 +31,15 @@
       ]
     },
     {
+      "login": "scottnonnenberg",
+      "name": "Scott Nonnenberg",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/443005?v=3",
+      "profile": "https://github.com/scottnonnenberg",
+      "contributions": [
+        "code", "test"
+      ]
+    },
+    {
       "login": "mgol",
       "name": "Michał Gołębiowski",
       "avatar_url": "https://avatars3.githubusercontent.com/u/1758366?v=3",

--- a/src/lib/rule-finder.js
+++ b/src/lib/rule-finder.js
@@ -33,16 +33,35 @@ function _getCurrentRules(config) {
   return Object.keys(config.rules)
 }
 
+function _normalizePluginName(name) {
+  var scopedRegex = /(@[^/]+)\/(.+)/
+  var match = scopedRegex.exec(name)
+
+  if (match) {
+    return {
+      module: match[1] + '/' + 'eslint-plugin-' + match[2],
+      prefix: match[2],
+    }
+  }
+
+  return {
+    module: 'eslint-plugin-' + name,
+    prefix: name,
+  }
+}
+
 function _getPluginRules(config) {
   var pluginRules = []
   var plugins = config.plugins
   if (plugins) {
     plugins.forEach(function getPluginRule(plugin) {
-      var pluginConfig = require('eslint-plugin-' + plugin)
+      var normalized = _normalizePluginName(plugin)
+      var pluginConfig = require(normalized.module)
+
       var rules = pluginConfig.rules
       pluginRules = pluginRules.concat(
         Object.keys(rules).map(function normalizePluginRule(rule) {
-          return plugin + '/' + rule
+          return normalized.prefix + '/' + rule
         })
       )
     })

--- a/test/fixtures/eslint.json
+++ b/test/fixtures/eslint.json
@@ -1,6 +1,10 @@
 {
   "extends": "./eslint.yml",
   "plugins": [
-    "react"
-  ]
+    "plugin",
+    "@scope/scoped-plugin"
+  ],
+  "rules": {
+    "scoped-plugin/foo-rule": [2]
+  }
 }

--- a/test/lib/rule-finder.js
+++ b/test/lib/rule-finder.js
@@ -10,11 +10,19 @@ var getRuleFinder = proxyquire('../../src/lib/rule-finder', {
       return ['foo-rule.js', 'bar-rule.js', 'baz-rule.js']
     },
   },
-  'eslint-plugin-react': {
+  'eslint-plugin-plugin': {
     rules: {
       'foo-rule': true,
       'bar-rule': true,
       'baz-rule': true,
+    },
+    '@noCallThru': true,
+    '@global': true,
+  },
+  '@scope/eslint-plugin-scoped-plugin': {
+    rules: {
+      'foo-rule': true,
+      'bar-rule': true,
     },
     '@noCallThru': true,
     '@global': true,
@@ -77,57 +85,107 @@ describe('rule-finder', function() {
 
   it('specifiedFile (relative path) is passed to the constructor', function() {
     var ruleFinder = getRuleFinder(specifiedFileRelative)
-    assert.deepEqual(ruleFinder.getUnusedRules(), ['baz-rule', 'react/bar-rule', 'react/baz-rule', 'react/foo-rule'])
+    assert.deepEqual(ruleFinder.getUnusedRules(), [
+      'baz-rule',
+      'plugin/bar-rule',
+      'plugin/baz-rule',
+      'plugin/foo-rule',
+      'scoped-plugin/bar-rule',
+    ])
   })
 
   it('specifiedFile (relative path) - current rules', function() {
     var ruleFinder = getRuleFinder(specifiedFileRelative)
-    assert.deepEqual(ruleFinder.getCurrentRules(), ['bar-rule', 'foo-rule'])
+    assert.deepEqual(ruleFinder.getCurrentRules(), ['bar-rule', 'foo-rule', 'scoped-plugin/foo-rule'])
   })
 
   it('specifiedFile (relative path) - current rule config', function() {
     var ruleFinder = getRuleFinder(specifiedFileRelative)
-    assert.deepEqual(ruleFinder.getCurrentRulesDetailed(), {'bar-rule': [2], 'foo-rule': [2]})
+    assert.deepEqual(ruleFinder.getCurrentRulesDetailed(), {
+      'bar-rule': [2],
+      'foo-rule': [2],
+      'scoped-plugin/foo-rule': [2],
+    })
   })
 
   it('specifiedFile (relative path) - plugin rules', function() {
     var ruleFinder = getRuleFinder(specifiedFileRelative)
-    assert.deepEqual(ruleFinder.getPluginRules(), ['react/bar-rule', 'react/baz-rule', 'react/foo-rule'])
+    assert.deepEqual(ruleFinder.getPluginRules(), [
+      'plugin/bar-rule',
+      'plugin/baz-rule',
+      'plugin/foo-rule',
+      'scoped-plugin/bar-rule',
+      'scoped-plugin/foo-rule',
+    ])
   })
 
   it('specifiedFile (relative path) - all available rules', function() {
     var ruleFinder = getRuleFinder(specifiedFileRelative)
     assert.deepEqual(
       ruleFinder.getAllAvailableRules(),
-      ['bar-rule', 'baz-rule', 'foo-rule', 'react/bar-rule', 'react/baz-rule', 'react/foo-rule']
+      [
+        'bar-rule',
+        'baz-rule',
+        'foo-rule',
+        'plugin/bar-rule',
+        'plugin/baz-rule',
+        'plugin/foo-rule',
+        'scoped-plugin/bar-rule',
+        'scoped-plugin/foo-rule',
+      ]
     )
   })
 
   it('specifiedFile (absolut path) is passed to the constructor', function() {
     var ruleFinder = getRuleFinder(specifiedFileAbsolute)
-    assert.deepEqual(ruleFinder.getUnusedRules(), ['baz-rule', 'react/bar-rule', 'react/baz-rule', 'react/foo-rule'])
+    assert.deepEqual(ruleFinder.getUnusedRules(), [
+      'baz-rule',
+      'plugin/bar-rule',
+      'plugin/baz-rule',
+      'plugin/foo-rule',
+      'scoped-plugin/bar-rule',
+    ])
   })
 
   it('specifiedFile (absolut path) - current rules', function() {
     var ruleFinder = getRuleFinder(specifiedFileAbsolute)
-    assert.deepEqual(ruleFinder.getCurrentRules(), ['bar-rule', 'foo-rule'])
+    assert.deepEqual(ruleFinder.getCurrentRules(), ['bar-rule', 'foo-rule', 'scoped-plugin/foo-rule'])
   })
 
   it('specifiedFile (absolut path) - current rule config', function() {
     var ruleFinder = getRuleFinder(specifiedFileAbsolute)
-    assert.deepEqual(ruleFinder.getCurrentRulesDetailed(), {'foo-rule': [2], 'bar-rule': [2]})
+    assert.deepEqual(ruleFinder.getCurrentRulesDetailed(), {
+      'foo-rule': [2],
+      'bar-rule': [2],
+      'scoped-plugin/foo-rule': [2],
+    })
   })
 
   it('specifiedFile (absolut path) - plugin rules', function() {
     var ruleFinder = getRuleFinder(specifiedFileAbsolute)
-    assert.deepEqual(ruleFinder.getPluginRules(), ['react/bar-rule', 'react/baz-rule', 'react/foo-rule'])
+    assert.deepEqual(ruleFinder.getPluginRules(), [
+      'plugin/bar-rule',
+      'plugin/baz-rule',
+      'plugin/foo-rule',
+      'scoped-plugin/bar-rule',
+      'scoped-plugin/foo-rule',
+    ])
   })
 
   it('specifiedFile (absolut path) - all available rules', function() {
     var ruleFinder = getRuleFinder(specifiedFileAbsolute)
     assert.deepEqual(
       ruleFinder.getAllAvailableRules(),
-      ['bar-rule', 'baz-rule', 'foo-rule', 'react/bar-rule', 'react/baz-rule', 'react/foo-rule']
+      [
+        'bar-rule',
+        'baz-rule',
+        'foo-rule',
+        'plugin/bar-rule',
+        'plugin/baz-rule',
+        'plugin/foo-rule',
+        'scoped-plugin/bar-rule',
+        'scoped-plugin/foo-rule',
+      ]
     )
   })
 })


### PR DESCRIPTION
I was getting this error:

```
Error: Cannot find module 'eslint-plugin-@scottnonnenberg/thehelp'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at getPluginRule (node_modules/eslint-find-rules/src/lib/rule-finder.js:41:26)
    ...
```