### PR TITLE
chore(peer-deps): updated eslint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "validate-commit-msg": "2.6.1"
   },
   "peerDependencies": {
-    "eslint": "^2.0.0"
+    "eslint": "^2.0.0 || ^3.0.0"
   },
   "eslintConfig": {
     "extends": "kentcdodds",


### PR DESCRIPTION
BREAKING CHANGE: eslint ^3.0.0 is desired as peer deps