### PR TITLE
feat(find): add rule documentation links in verbose mode (fixes #141)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
   "license": "MIT",
   "dependencies": {
     "cliui": "^3.2.0",
+    "eslint-rule-documentation": "^1.0.0",
     "path-is-absolute": "1.0.0",
-    "window-size": "^0.2.0",
     "which": "^1.2.8",
+    "window-size": "^0.2.0",
     "yargs": "^4.4.0"
   },
   "devDependencies": {

--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -38,8 +38,12 @@ Object.keys(options).forEach(function findRules(option) {
     rules = ruleFinderMethod()
     argv.verbose && cli.push('\n' + options[option][0] + ' rules\n' + rules.length + ' rules found\n')
     if (rules.length) {
-      !argv.verbose && cli.push('\n' + options[option][0] + ' rules\n')
-      cli.push(rules)
+      if (argv.verbose) {
+        cli.verbosePush(rules)
+      } else {
+        cli.push('\n' + options[option][0] + ' rules\n')
+        cli.push(rules)
+      }
       cli.write()
     } else /* istanbul ignore else */ if (option === 'getUnusedRules') {
       processExitCode = 0

--- a/src/lib/cli-util.js
+++ b/src/lib/cli-util.js
@@ -1,3 +1,4 @@
+var getRuleURI = require('eslint-rule-documentation')
 var size = require('window-size')
 var availableWidth = size.width || /*istanbul ignore next */ 80
 var ui = require('cliui')({width: availableWidth})
@@ -19,6 +20,14 @@ function push(output, columns) {
   }
 }
 
+function verbosePush(output) {
+  var _output = [].concat(output).map(function(rule) {
+    return rule + '\t' + getRuleURI(rule).url
+  })
+
+  push(_output, 1)
+}
+
 function write(logger) {
   var _logger = logger || console
   var _log = _logger.log || /* istanbul ignore next */ console.log // eslint-disable-line no-console
@@ -37,5 +46,6 @@ function getOutputCellMapper(width, padding) {
 
 module.exports = {
   push: push,
+  verbosePush: verbosePush,
   write: write,
 }


### PR DESCRIPTION
feat(find): add rule documentation links in verbose mode (fixes #141)

This adds document links to the verbose output. The verbose mode now prints everything in one column (or rather two: one for the rule name, one for the link). This is what it looks like
![image](https://cloud.githubusercontent.com/assets/3869412/17308177/f5754f04-5838-11e6-8b68-c6629d930633.png)

It's not as pretty as the non-verbose mode, as things are not aligned. Maybe at some point color could be added to the link and/or rule name.

Let me know what you think!