### PR TITLE
feat(find): add `nocore` option (#130)

### DIFF
--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -8,7 +8,7 @@ var options = {
   getAllAvailableRules: ['all-available', 'a'],
   getUnusedRules: ['unused', 'u'],
   n: ['no-error'],
-  noCore: ['nocore', 'C'],
+  nc: ['no-core'],
   verbose: ['verbose', 'v'],
 }
 
@@ -23,7 +23,7 @@ var processExitCode = argv.u && !argv.n ? 1 : 0
 var getRuleFinder = require('../lib/rule-finder')
 var specifiedFile = argv._[0]
 
-var ruleFinder = getRuleFinder(specifiedFile, argv.noCore)
+var ruleFinder = getRuleFinder(specifiedFile, argv.core === false)
 
 if (!argv.c && !argv.p && !argv.a && !argv.u) {
   console.log('no option provided, please provide a valid option') // eslint-disable-line no-console

--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -8,6 +8,7 @@ var options = {
   getAllAvailableRules: ['all-available', 'a'],
   getUnusedRules: ['unused', 'u'],
   n: ['no-error'],
+  noCore: ['nocore', 'C'],
   verbose: ['verbose', 'v'],
 }
 
@@ -22,7 +23,7 @@ var processExitCode = argv.u && !argv.n ? 1 : 0
 var getRuleFinder = require('../lib/rule-finder')
 var specifiedFile = argv._[0]
 
-var ruleFinder = getRuleFinder(specifiedFile)
+var ruleFinder = getRuleFinder(specifiedFile, argv.noCore)
 
 if (!argv.c && !argv.p && !argv.a && !argv.u) {
   console.log('no option provided, please provide a valid option') // eslint-disable-line no-console

--- a/src/lib/rule-finder.js
+++ b/src/lib/rule-finder.js
@@ -93,11 +93,9 @@ function RuleFinder(specifiedFile, noCore) {
   var config = _getConfig(configFile)
   var currentRules = _getCurrentRules(config)
   var pluginRules = _getPluginRules(config)
-  var allRules = pluginRules
+  var allRules = noCore ? pluginRules : _getAllAvailableRules(pluginRules)
   if (noCore) {
     currentRules = currentRules.filter(_isNotCore)
-  } else {
-    allRules = _getAllAvailableRules(pluginRules)
   }
   var unusedRules = difference(allRules, currentRules) // eslint-disable-line vars-on-top
 

--- a/src/lib/rule-finder.js
+++ b/src/lib/rule-finder.js
@@ -84,13 +84,22 @@ function _getAllAvailableRules(pluginRules) {
   return filteredAllRules
 }
 
-function RuleFinder(specifiedFile) {
+function _isNotCore(rule) {
+  return rule.indexOf('/') !== '-1'
+}
+
+function RuleFinder(specifiedFile, noCore) {
   var configFile = _getConfigFile(specifiedFile)
   var config = _getConfig(configFile)
   var currentRules = _getCurrentRules(config)
   var pluginRules = _getPluginRules(config)
-  var allRules = _getAllAvailableRules(pluginRules)
-  var unusedRules = difference(allRules, currentRules)
+  var allRules = pluginRules
+  if (noCore) {
+    currentRules = currentRules.filter(_isNotCore)
+  } else {
+    allRules = _getAllAvailableRules(pluginRules)
+  }
+  var unusedRules = difference(allRules, currentRules) // eslint-disable-line vars-on-top
 
   // get all the current rules instead of referring the extended files or documentation
   this.getCurrentRules = function getCurrentRules() {
@@ -118,6 +127,6 @@ function RuleFinder(specifiedFile) {
 
 }
 
-module.exports = function getRuleFinder(specifiedFile) {
-  return new RuleFinder(specifiedFile)
+module.exports = function getRuleFinder(specifiedFile, noCore) {
+  return new RuleFinder(specifiedFile, noCore)
 }

--- a/test/lib/rule-finder.js
+++ b/test/lib/rule-finder.js
@@ -83,6 +83,15 @@ describe('rule-finder', function() {
     assert.deepEqual(ruleFinder.getAllAvailableRules(), ['bar-rule', 'baz-rule', 'foo-rule'])
   })
 
+  it('no specifiedFile - all available rules without core', function() {
+    var ruleFinder
+    process.cwd = function() {
+      return noSpecifiedFile
+    }
+    ruleFinder = getRuleFinder(null, true)
+    assert.deepEqual(ruleFinder.getAllAvailableRules(), [])
+  })
+
   it('specifiedFile (relative path) is passed to the constructor', function() {
     var ruleFinder = getRuleFinder(specifiedFileRelative)
     assert.deepEqual(ruleFinder.getUnusedRules(), [
@@ -136,7 +145,21 @@ describe('rule-finder', function() {
     )
   })
 
-  it('specifiedFile (absolut path) is passed to the constructor', function() {
+  it('specifiedFile (relative path) - all available rules without core', function() {
+    var ruleFinder = getRuleFinder(specifiedFileRelative, true)
+    assert.deepEqual(
+      ruleFinder.getAllAvailableRules(),
+      [
+        'plugin/bar-rule',
+        'plugin/baz-rule',
+        'plugin/foo-rule',
+        'scoped-plugin/bar-rule',
+        'scoped-plugin/foo-rule',
+      ]
+    )
+  })
+
+  it('specifiedFile (absolute path) is passed to the constructor', function() {
     var ruleFinder = getRuleFinder(specifiedFileAbsolute)
     assert.deepEqual(ruleFinder.getUnusedRules(), [
       'baz-rule',
@@ -147,12 +170,12 @@ describe('rule-finder', function() {
     ])
   })
 
-  it('specifiedFile (absolut path) - current rules', function() {
+  it('specifiedFile (absolute path) - current rules', function() {
     var ruleFinder = getRuleFinder(specifiedFileAbsolute)
     assert.deepEqual(ruleFinder.getCurrentRules(), ['bar-rule', 'foo-rule', 'scoped-plugin/foo-rule'])
   })
 
-  it('specifiedFile (absolut path) - current rule config', function() {
+  it('specifiedFile (absolute path) - current rule config', function() {
     var ruleFinder = getRuleFinder(specifiedFileAbsolute)
     assert.deepEqual(ruleFinder.getCurrentRulesDetailed(), {
       'foo-rule': [2],
@@ -161,7 +184,7 @@ describe('rule-finder', function() {
     })
   })
 
-  it('specifiedFile (absolut path) - plugin rules', function() {
+  it('specifiedFile (absolute path) - plugin rules', function() {
     var ruleFinder = getRuleFinder(specifiedFileAbsolute)
     assert.deepEqual(ruleFinder.getPluginRules(), [
       'plugin/bar-rule',
@@ -172,7 +195,7 @@ describe('rule-finder', function() {
     ])
   })
 
-  it('specifiedFile (absolut path) - all available rules', function() {
+  it('specifiedFile (absolute path) - all available rules', function() {
     var ruleFinder = getRuleFinder(specifiedFileAbsolute)
     assert.deepEqual(
       ruleFinder.getAllAvailableRules(),


### PR DESCRIPTION
feat(find): add `nocore` option (#130)

Allows users to use

```
eslint-find-rules --no-core --unused <file>
# or
eslint-find-rules -C --unused <file>
```

Let me know what you think!