### PR TITLE
fix(find): make rule documentation output aligned in columns

### DIFF
--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -17,6 +17,8 @@ var argv = require('yargs')
   .alias(options)
   .argv
 
+var getRuleURI = require('eslint-rule-documentation')
+
 var cli = require('../lib/cli-util')
 
 var processExitCode = argv.u && !argv.n ? 1 : 0
@@ -40,7 +42,12 @@ Object.keys(options).forEach(function findRules(option) {
     argv.verbose && cli.push('\n' + options[option][0] + ' rules\n' + rules.length + ' rules found\n')
     if (rules.length) {
       if (argv.verbose) {
-        cli.verbosePush(rules)
+        rules = rules.map(function(rule) {
+          return [rule, getRuleURI(rule).url]
+        }).reduce(function(all, single) {
+          return all.concat(single)
+        })
+        cli.push(rules, 2, false)
       } else {
         cli.push('\n' + options[option][0] + ' rules\n')
         cli.push(rules)

--- a/src/lib/cli-util.js
+++ b/src/lib/cli-util.js
@@ -1,31 +1,36 @@
-var getRuleURI = require('eslint-rule-documentation')
 var size = require('window-size')
 var availableWidth = size.width || /*istanbul ignore next */ 80
 var ui = require('cliui')({width: availableWidth})
 
-function push(output, columns) {
+function push(output, columns, uniformColWidths) {
   var _output = [].concat(output)
 
   var padding = {top: 0, right: 2, bottom: 0, left: 0}
-  var width = _output.reduce(
+  var maxWidth = [_output.reduce(
     function getMaxWidth(previous, current) {
       return Math.max(padding.left + current.length + padding.right, previous)
-    }, 0)
+    }, 0)]
 
-  var _columns = columns || Math.floor(availableWidth / width)
-  var cellMapper = getOutputCellMapper(Math.floor(availableWidth / _columns), padding)
+  var _columns = columns || Math.floor(availableWidth / maxWidth)
+  var cellMapper, widths
+
+  if (uniformColWidths === false && _columns > 1) {
+    widths = []
+    _output.forEach(function(content, index) {
+      widths[index % _columns] = Math.max(
+        padding.left + content.length + padding.right,
+        widths[index % _columns] || 0
+      )
+    })
+  } else {
+    widths = [Math.floor(availableWidth / _columns)]
+  }
+
+  cellMapper = getOutputCellMapper(widths, padding)
 
   while (_output.length) {
     ui.div.apply(ui, _output.splice(0, _columns).map(cellMapper))
   }
-}
-
-function verbosePush(output) {
-  var _output = [].concat(output).map(function(rule) {
-    return rule + '\t' + getRuleURI(rule).url
-  })
-
-  push(_output, 1)
 }
 
 function write(logger) {
@@ -34,11 +39,15 @@ function write(logger) {
   _log(ui.toString())
 }
 
-function getOutputCellMapper(width, padding) {
-  return function curriedOutputCellMapper(text) {
+function getOutputCellMapper(widths, padding) {
+  return function curriedOutputCellMapper(text, index) {
+    var _width = widths[index]
+    if (_width === undefined) {
+      _width = widths[0]
+    }
     return {
       text: text,
-      width: width,
+      width: _width,
       padding: [padding.top, padding.right, padding.bottom, padding.left],
     }
   }
@@ -46,6 +55,5 @@ function getOutputCellMapper(width, padding) {
 
 module.exports = {
   push: push,
-  verbosePush: verbosePush,
   write: write,
 }

--- a/test/bin/find.js
+++ b/test/bin/find.js
@@ -5,10 +5,10 @@ var sinon = require('sinon')
 var consoleLog = console.log // eslint-disable-line no-console
 var processExit = process.exit
 
-var getCurrentRules = sinon.stub().returns(['current'])
-var getPluginRules = sinon.stub().returns(['plugin'])
-var getAllAvailableRules = sinon.stub().returns(['all-available'])
-var getUnusedRules = sinon.stub().returns(['unused'])
+var getCurrentRules = sinon.stub().returns(['current', 'rules'])
+var getPluginRules = sinon.stub().returns(['plugin', 'rules'])
+var getAllAvailableRules = sinon.stub().returns(['all', 'available'])
+var getUnusedRules = sinon.stub().returns(['unused', 'rules'])
 
 var stub = {
   '../lib/rule-finder': function() {


### PR DESCRIPTION
As the title says (I was impatient and thus not able to wait until after the planned "es2015ification") ...

![image](https://cloud.githubusercontent.com/assets/262436/17485105/e7a3fc1e-5d8c-11e6-9418-93faf8c7a990.png)

I moved the whole `getRuleURI` logic out of `lib/cli-util` and into `bin/find` (where it belongs imo), altered the `push` method to accept `uniformColWidths` (calculates the columns' widths individually if explicitly set to `false`) — this made the `verbosePush` method obsolete.  
Finally tweaked the tests due to a warning, that the coverage would not meet global threshold (`reduce`ing the array, enriched with the rule documentation links was reported as untested).