### PR TITLE
Fix crash when no rules

### DIFF
--- a/src/lib/rule-finder.js
+++ b/src/lib/rule-finder.js
@@ -58,7 +58,7 @@ function _getPluginRules(config) {
       var normalized = _normalizePluginName(plugin)
       var pluginConfig = require(normalized.module)
 
-      var rules = pluginConfig.rules
+      var rules = pluginConfig.rules === undefined ? {} : pluginConfig.rules
       pluginRules = pluginRules.concat(
         Object.keys(rules).map(function normalizePluginRule(rule) {
           return normalized.prefix + '/' + rule

--- a/test/fixtures/eslint-with-plugin-with-no-rules.json
+++ b/test/fixtures/eslint-with-plugin-with-no-rules.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "plugin",
+    "no-rules"
+  ],
+  "rules": {}
+}

--- a/test/lib/rule-finder.js
+++ b/test/lib/rule-finder.js
@@ -19,6 +19,11 @@ var getRuleFinder = proxyquire('../../src/lib/rule-finder', {
     '@noCallThru': true,
     '@global': true,
   },
+  'eslint-plugin-no-rules': {
+    processors: {},
+    '@noCallThru': true,
+    '@global': true,
+  },
   '@scope/eslint-plugin-scoped-plugin': {
     rules: {
       'foo-rule': true,
@@ -32,6 +37,7 @@ var getRuleFinder = proxyquire('../../src/lib/rule-finder', {
 var noSpecifiedFile = path.resolve(process.cwd(), './test/fixtures/no-path')
 var specifiedFileRelative = './test/fixtures/eslint.json'
 var specifiedFileAbsolute = path.join(process.cwd(), specifiedFileRelative)
+var noRulesFile = path.join(process.cwd(), './test/fixtures/eslint-with-plugin-with-no-rules.json')
 
 describe('rule-finder', function() {
   afterEach(function() {
@@ -210,5 +216,14 @@ describe('rule-finder', function() {
         'scoped-plugin/foo-rule',
       ]
     )
+  })
+
+  it('specifiedFile (absolute path) without rules - plugin rules', function() {
+    var ruleFinder = getRuleFinder(noRulesFile)
+    assert.deepEqual(ruleFinder.getPluginRules(), [
+      'plugin/bar-rule',
+      'plugin/baz-rule',
+      'plugin/foo-rule',
+    ])
   })
 })


### PR DESCRIPTION
I found a crash when having eslint-plugin-json in my config. The reason is that the plugin does not have any rules, and that when do stuff on that value that we did not assume could be  `undefined`.

The fix is pretty simple, it worked for me when I tampered with it in my node_modules, but I can't seem to write any tests for it. I'm getting the following error. Let me know if you have some tips on getting that working :)
```
1) rule-finder specifiedFile (absolute path) without rules - plugin rules:
     Error: Failed to load plugin no-rules: Cannot find module 'eslint-plugin-no-rules'
```