### PR TITLE
feat(find): underline urls in verbose mode (fixes #178)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "chalk": "^1.1.3",
     "cliui": "^3.2.0",
     "eslint-rule-documentation": "^1.0.0",
     "path-is-absolute": "1.0.0",

--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -20,6 +20,7 @@ var argv = require('yargs')
 var getRuleURI = require('eslint-rule-documentation')
 
 var cli = require('../lib/cli-util')
+var chalk = require('chalk')
 
 var processExitCode = argv.u && !argv.n ? 1 : 0
 var getRuleFinder = require('../lib/rule-finder')
@@ -43,7 +44,7 @@ Object.keys(options).forEach(function findRules(option) {
     if (rules.length) {
       if (argv.verbose) {
         rules = rules.map(function(rule) {
-          return [rule, getRuleURI(rule).url]
+          return [rule, chalk.underline(getRuleURI(rule).url)]
         }).reduce(function(all, single) {
           return all.concat(single)
         })


### PR DESCRIPTION
Underline urls in verbose mode (fixes #178)

Visual result:
![image](https://cloud.githubusercontent.com/assets/3869412/18895429/e97ee4c2-8519-11e6-8893-11be5bc7b66c.png)
