### PR TITLE
fix(doc): updated usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The intended usage is as an npm script:
 ```
 
 ```
-available options are -c|--current, -a|--all-available, -p|--plugin, -u|--unused
-available flag is -n|--no-error
+available options are -c|--current, -a|-all-available, -p|--plugin, -u|--unused
+available flag is -n|-no-error
 ```
 
 By default it will error out only for `-u|--unused`,
@@ -57,8 +57,8 @@ Then run it with: `$ npm run eslint-find-option-rules -s` (the `-s` is to silenc
 This is really handy in an actual config module (like [eslint-config-kentcdodds](https://github.com/kentcdodds/eslint-config-kentcdodds)) where you could also do:
 
 ```
-// available options are -c|--current, -a|--all-available, -p|--plugin, -u|--unused
-eslint-find-rules --option ./index.js
+// available options are -c|--current, -a|-all-available, -p|--plugin, -u|--unused
+eslint-find-rules --option|-hyphenated-option ./index.js
 ```
 
 This is resolved, relative to the `process.cwd()` which, in the context of `npm` scripts is always the location of your `package.json`.
@@ -70,7 +70,7 @@ You may specify any [config format supported by ESLint](http://eslint.org/docs/u
 You can also provide an absolute path:
 
 ```
-eslint-find-rules --option ~/Developer/eslint-config-kentcdodds/index.js
+eslint-find-rules --option|-hyphenated-option ~/Developer/eslint-config-kentcdodds/index.js
 ```
 
 **Please note** that any tested ESLint config file must reside below your project's root.
@@ -80,7 +80,7 @@ eslint-find-rules --option ~/Developer/eslint-config-kentcdodds/index.js
 It will also default to the `main` in your `package.json`, so you can omit the `path/to/file` argument:
 
 ```
-eslint-find-rules --option
+eslint-find-rules --option|-hyphenated-option
 ```
 
 ### As a `require`d module

--- a/test/bin/find.js
+++ b/test/bin/find.js
@@ -59,16 +59,25 @@ describe('bin', function() {
     process.argv[2] = '-c'
     proxyquire('../../src/bin/find', stub)
     assert.ok(getCurrentRules.called)
+    process.argv[2] = '--current'
+    proxyquire('../../src/bin/find', stub)
+    assert.ok(getCurrentRules.called)
   })
 
   it('option -p|--plugin', function() {
     process.argv[2] = '-p'
     proxyquire('../../src/bin/find', stub)
     assert.ok(getPluginRules.called)
+    process.argv[2] = '--plugin'
+    proxyquire('../../src/bin/find', stub)
+    assert.ok(getPluginRules.called)
   })
 
-  it('option -a|--all-available', function() {
+  it('option -a|-all-available', function() {
     process.argv[2] = '-a'
+    proxyquire('../../src/bin/find', stub)
+    assert.ok(getAllAvailableRules.called)
+    process.argv[2] = '-all-available'
     proxyquire('../../src/bin/find', stub)
     assert.ok(getAllAvailableRules.called)
   })
@@ -80,9 +89,12 @@ describe('bin', function() {
     process.argv[2] = '-u'
     proxyquire('../../src/bin/find', stub)
     assert.ok(getUnusedRules.called)
+    process.argv[2] = '--unused'
+    proxyquire('../../src/bin/find', stub)
+    assert.ok(getUnusedRules.called)
   })
 
-  it('options -u|--unused and no unused rules found', function() {
+  it('options -u|-unused and no unused rules found', function() {
     getUnusedRules.returns([])
     process.exit = function(status) {
       assert.equal(status, 0)
@@ -90,9 +102,12 @@ describe('bin', function() {
     process.argv[2] = '-u'
     proxyquire('../../src/bin/find', stub)
     assert.ok(getUnusedRules.called)
+    process.argv[2] = '--unused'
+    proxyquire('../../src/bin/find', stub)
+    assert.ok(getUnusedRules.called)
   })
 
-  it('option -u|--unused along with -n|no-error', function() {
+  it('option -u|-unused along with -n|-no-error', function() {
     process.exit = function(status) {
       assert.equal(status, 0)
     }
@@ -100,11 +115,20 @@ describe('bin', function() {
     process.argv[3] = '-n'
     proxyquire('../../src/bin/find', stub)
     assert.ok(getUnusedRules.called)
+
+    process.argv[2] = '--unused'
+    process.argv[3] = '-no-error'
+    proxyquire('../../src/bin/find', stub)
+    assert.ok(getUnusedRules.called)
   })
 
   it('logs verbosely', function() {
     process.argv[2] = '-c'
     process.argv[3] = '-v'
+    proxyquire('../../src/bin/find', stub)
+    assert.ok(getCurrentRules.called)
+    process.argv[2] = '--current'
+    process.argv[3] = '--verbose'
     proxyquire('../../src/bin/find', stub)
     assert.ok(getCurrentRules.called)
   })


### PR DESCRIPTION
and corresponding test
for hyphenated options prefix it with
single dash (-) instead of double dashes (--)

fixes #194 
