### PR TITLE
refactor(find): Use new eslint getRules() api

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -65,6 +65,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "randycoulman",
+      "name": "Randy Coulman",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/1406203?v=3",
+      "profile": "https://github.com/randycoulman",
+      "contributions": [
+        "code", "test"
+      ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "codecov": "1.0.1",
     "commitizen": "2.8.6",
     "cz-conventional-changelog": "1.2.0",
-    "eslint": "3.5.0",
+    "eslint": "3.12.0",
     "ghooks": "1.3.2",
     "mocha": "^3.0.1",
     "npm-run-all": "3.1.0",
@@ -60,7 +60,7 @@
     "xo": "^0.17.0"
   },
   "peerDependencies": {
-    "eslint": "^2.0.0 || ^3.0.0"
+    "eslint": "^3.12.0"
   },
   "nyc": {
     "exclude": [

--- a/src/lib/rule-finder.js
+++ b/src/lib/rule-finder.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const fs = require('fs');
 
 const eslint = require('eslint');
 const isAbsolute = require('path-is-absolute');
@@ -68,18 +67,10 @@ function _getPluginRules(config) {
 }
 
 function _getAllAvailableRules(pluginRules) {
-  const allRules = fs
-    .readdirSync('./node_modules/eslint/lib/rules');
-  let filteredAllRules = [];
-  allRules.forEach(filename => {
-    if (filename.slice(-3) === '.js') {
-      filteredAllRules.push(filename.replace(/\.js$/, ''));
-    }
-  });
-
-  filteredAllRules = filteredAllRules.concat(pluginRules);
-
-  return filteredAllRules;
+  return [
+    ...eslint.linter.getRules().keys(),
+    ...pluginRules
+  ];
 }
 
 function _isNotCore(rule) {

--- a/test/lib/rule-finder.js
+++ b/test/lib/rule-finder.js
@@ -5,9 +5,14 @@ const proxyquire = require('proxyquire');
 const processCwd = process.cwd;
 
 const getRuleFinder = proxyquire('../../src/lib/rule-finder', {
-  fs: {
-    readdirSync() {
-      return ['.eslintrc.yml', 'foo-rule.js', 'bar-rule.js', 'baz-rule.js'];
+  eslint: {
+    linter: {
+      getRules() {
+        return new Map()
+          .set('foo-rule', {})
+          .set('bar-rule', {})
+          .set('baz-rule', {});
+      }
     }
   },
   'eslint-plugin-plugin': {


### PR DESCRIPTION
**Breaking change:** Requires eslint >= 3.12.0

Starting with version 3.12.0, eslint provides a getRules() API that allows us to directly access the rules rather than trying to load them from the file system.  This is cleaner, eliminates a dependency on the internal structure of the eslint codebase.

This change paves the way for further features involving deprecated rules, such as #172 and #188.

Note that eslint returns a `Map` object containing the rules, so we can’t use `Object.keys()` to get the keys out.

We are not yet using the rule objects themselves, so the test stubs just return empty objects for now.

Closes #211.