### PR TITLE
feat(rule-finder): Omit deprecated rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ to list current configured rules, all-available rules, unused rules, and plugin 
 [![downloads](https://img.shields.io/npm/dm/eslint-find-rules.svg?style=flat-square)](http://npm-stat.com/charts.html?package=eslint-find-rules&from=2015-08-01)
 [![MIT License](https://img.shields.io/npm/l/eslint-find-rules.svg?style=flat-square)](http://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
-[![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors)
 
 ## Acknowledgment
 
@@ -42,15 +42,21 @@ The intended usage is as an npm script:
 }
 ```
 
+Then run it with: `$ npm run --silent eslint-find-option-rules` (the `--silent` is to silence npm output).
+
 ```
 available options are -c|--current, -a|--all-available, -p|--plugin, -u|--unused
-available flag is -n|--no-error
+available flags are -n|--no-error, --no-core, and -i/--include deprecated
 ```
 
 By default it will error out only for `-u|--unused`,
-however if you do not want the `process` to `exit` with a `non-zero` exit code, use the `-n|--no-error` along with `-u|--unused`
+however if you do not want the `process` to `exit` with a `non-zero` exit code, use the `-n|--no-error` flag along with `-u|--unused`.
 
-Then run it with: `$ npm run eslint-find-option-rules -s` (the `-s` is to silence npm output).
+By default, core rules will be included in the output of `-c|--current`, `-a|--all-available`, and `-u|--unused`.  If you want to report on plugin rules only, use the `--no-core` flag.
+
+By default, deprecated rules will be omitted from the output of `-a|--all-available`, `-p|--plugin` and `-u|--unused`.  If you want to report on deprecated rules as well, use the `--include=deprecated` or `-i deprecated` flag.
+
+**NOTE:** Deprecated rules are found by looking at the metadata of the rule definition.  All core rules and many plugin rules use this flag to indicate deprecated rules.  But if you find a plugin that does not mark their rules as deprecated in the rule metadata, please file a pull request with that project.
 
 ### Specify a file
 
@@ -123,8 +129,9 @@ ruleFinder.getUnusedRules()
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [![Sarbbottam Bandyopadhyay](https://avatars1.githubusercontent.com/u/949380?v=3&s=100)<br /><sub>Sarbbottam Bandyopadhyay</sub>](https://twitter.com/sarbbottam)<br />[💻](https://github.com/sarbbottam/eslint-find-rules/commits?author=sarbbottam) [📖](https://github.com/sarbbottam/eslint-find-rules/commits?author=sarbbottam) [⚠️](https://github.com/sarbbottam/eslint-find-rules/commits?author=sarbbottam) 👀 | [![Andreas Windt](https://avatars1.githubusercontent.com/u/262436?v=3&s=100)<br /><sub>Andreas Windt</sub>](https://twitter.com/ta2edchimp)<br />[💻](https://github.com/sarbbottam/eslint-find-rules/commits?author=ta2edchimp) [📖](https://github.com/sarbbottam/eslint-find-rules/commits?author=ta2edchimp) [⚠️](https://github.com/sarbbottam/eslint-find-rules/commits?author=ta2edchimp) 👀 | [![Kent C. Dodds](https://avatars3.githubusercontent.com/u/1500684?v=3&s=100)<br /><sub>Kent C. Dodds</sub>](https://twitter.com/kentcdodds)<br />[💻](https://github.com/sarbbottam/eslint-find-rules/commits?author=kentcdodds) [📖](https://github.com/sarbbottam/eslint-find-rules/commits?author=kentcdodds) [⚠️](https://github.com/sarbbottam/eslint-find-rules/commits?author=kentcdodds) 👀 | [![Michał Gołębiowski](https://avatars3.githubusercontent.com/u/1758366?v=3&s=100)<br /><sub>Michał Gołębiowski</sub>](https://github.com/mgol)<br />[💻](https://github.com/sarbbottam/eslint-find-rules/commits?author=mgol) | [![Jeroen Engels](https://avatars.githubusercontent.com/u/3869412?v=3&s=100)<br /><sub>Jeroen Engels</sub>](https://github.com/jfmengels)<br />[📖](https://github.com/sarbbottam/eslint-find-rules/commits?author=jfmengels) | [![Dustin Specker](https://avatars2.githubusercontent.com/u/2449282?v=3&s=100)<br /><sub>Dustin Specker</sub>](https://github.com/dustinspecker)<br />[💻](https://github.com/sarbbottam/eslint-find-rules/commits?author=dustinspecker) |
-| :---: | :---: | :---: | :---: | :---: | :---: |
+| [<img src="https://avatars1.githubusercontent.com/u/949380?v=3" width="100px;"/><br /><sub>Sarbbottam Bandyopadhyay</sub>](https://twitter.com/sarbbottam)<br />[💻](https://github.com/sarbbottam/eslint-find-rules/commits?author=sarbbottam) [📖](https://github.com/sarbbottam/eslint-find-rules/commits?author=sarbbottam) [⚠️](https://github.com/sarbbottam/eslint-find-rules/commits?author=sarbbottam) 👀 | [<img src="https://avatars1.githubusercontent.com/u/262436?v=3" width="100px;"/><br /><sub>Andreas Windt</sub>](https://twitter.com/ta2edchimp)<br />[💻](https://github.com/sarbbottam/eslint-find-rules/commits?author=ta2edchimp) [📖](https://github.com/sarbbottam/eslint-find-rules/commits?author=ta2edchimp) [⚠️](https://github.com/sarbbottam/eslint-find-rules/commits?author=ta2edchimp) 👀 | [<img src="https://avatars3.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://twitter.com/kentcdodds)<br />[💻](https://github.com/sarbbottam/eslint-find-rules/commits?author=kentcdodds) [📖](https://github.com/sarbbottam/eslint-find-rules/commits?author=kentcdodds) [⚠️](https://github.com/sarbbottam/eslint-find-rules/commits?author=kentcdodds) 👀 | [<img src="https://avatars1.githubusercontent.com/u/443005?v=3" width="100px;"/><br /><sub>Scott Nonnenberg</sub>](https://github.com/scottnonnenberg)<br />[💻](https://github.com/sarbbottam/eslint-find-rules/commits?author=scottnonnenberg) [⚠️](https://github.com/sarbbottam/eslint-find-rules/commits?author=scottnonnenberg) | [<img src="https://avatars3.githubusercontent.com/u/1758366?v=3" width="100px;"/><br /><sub>Michał Gołębiowski</sub>](https://github.com/mgol)<br />[💻](https://github.com/sarbbottam/eslint-find-rules/commits?author=mgol) | [<img src="https://avatars.githubusercontent.com/u/3869412?v=3" width="100px;"/><br /><sub>Jeroen Engels</sub>](https://github.com/jfmengels)<br />[📖](https://github.com/sarbbottam/eslint-find-rules/commits?author=jfmengels) | [<img src="https://avatars2.githubusercontent.com/u/2449282?v=3" width="100px;"/><br /><sub>Dustin Specker</sub>](https://github.com/dustinspecker)<br />[💻](https://github.com/sarbbottam/eslint-find-rules/commits?author=dustinspecker) |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [<img src="https://avatars1.githubusercontent.com/u/1406203?v=3" width="100px;"/><br /><sub>Randy Coulman</sub>](https://github.com/randycoulman)<br />[💻](https://github.com/sarbbottam/eslint-find-rules/commits?author=randycoulman) [⚠️](https://github.com/sarbbottam/eslint-find-rules/commits?author=randycoulman) |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification.

--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -8,7 +8,6 @@ const options = {
   getUnusedRules: ['unused', 'u'],
   n: [],
   error: ['error'],
-  nc: [],
   core: ['core'],
   verbose: ['verbose', 'v']
 };
@@ -16,16 +15,24 @@ const options = {
 const argv = require('yargs')
   .boolean(Object.keys(options))
   .alias(options)
+  .option('include', {
+    alias: 'i',
+    choices: ['deprecated'],
+    type: 'string'
+  })
   .default('error', true)
   .default('core', true)
   .argv;
-
 const getRuleURI = require('eslint-rule-documentation');
 const getRuleFinder = require('../lib/rule-finder');
 const cli = require('../lib/cli-util');
 
 const specifiedFile = argv._[0];
-const ruleFinder = getRuleFinder(specifiedFile, argv.core === false);
+const finderOptions = {
+  omitCore: !argv.core,
+  includeDeprecated: argv.include === 'deprecated'
+};
+const ruleFinder = getRuleFinder(specifiedFile, finderOptions);
 const errorOut = argv.error && !argv.n;
 let processExitCode = argv.u && errorOut ? 1 : 0;
 

--- a/src/lib/rule-finder.js
+++ b/src/lib/rule-finder.js
@@ -80,7 +80,7 @@ function _isNotCore(rule) {
   return rule.indexOf('/') !== '-1';
 }
 
-function RuleFinder(specifiedFile, options) {
+function RuleFinder(specifiedFile, options = {}) {
   const {omitCore, includeDeprecated} = options;
   const configFile = _getConfigFile(specifiedFile);
   const config = _getConfig(configFile);
@@ -108,6 +108,6 @@ function RuleFinder(specifiedFile, options) {
   this.getUnusedRules = () => getSortedRules(unusedRules);
 }
 
-module.exports = function (specifiedFile, options = {}) {
+module.exports = function (specifiedFile, options) {
   return new RuleFinder(specifiedFile, options);
 };

--- a/src/lib/rule-finder.js
+++ b/src/lib/rule-finder.js
@@ -80,7 +80,7 @@ function _isNotCore(rule) {
   return rule.indexOf('/') !== '-1';
 }
 
-function RuleFinder(specifiedFile, options = {}) {
+function RuleFinder(specifiedFile, options) {
   const {omitCore, includeDeprecated} = options;
   const configFile = _getConfigFile(specifiedFile);
   const config = _getConfig(configFile);

--- a/test/bin/find.js
+++ b/test/bin/find.js
@@ -97,7 +97,7 @@ describe('bin', () => {
     assert.ok(getUnusedRules.called);
   });
 
-  it('option -u|--unused along with -n|--no-error', () => {
+  it('option -u|--unused along with -n', () => {
     process.exit = status => {
       assert.equal(status, 0);
     };
@@ -105,6 +105,12 @@ describe('bin', () => {
     process.argv[3] = '-n';
     proxyquire('../../src/bin/find', stub);
     assert.ok(getUnusedRules.called);
+  });
+
+  it('option -u|--unused along with --no-error', () => {
+    process.exit = status => {
+      assert.equal(status, 0);
+    };
     process.argv[2] = '-u';
     process.argv[3] = '--no-error';
     proxyquire('../../src/bin/find', stub);
@@ -120,10 +126,10 @@ describe('bin', () => {
 
   it('logs core rules', () => {
     stub = {
-      '../lib/rule-finder'(specifiedFile, noCore) {
+      '../lib/rule-finder'(specifiedFile, options) {
         return {
           getCurrentRules() {
-            assert(!noCore);
+            assert(!options.omitCore);
             return ['current', 'rules'];
           }
         };
@@ -133,12 +139,12 @@ describe('bin', () => {
     proxyquire('../../src/bin/find', stub);
   });
 
-  it('does not log core rules', () => {
+  it('does not log core rules with --no-core', () => {
     stub = {
-      '../lib/rule-finder'(specifiedFile, noCore) {
+      '../lib/rule-finder'(specifiedFile, options) {
         return {
           getCurrentRules() {
-            assert(noCore);
+            assert(options.omitCore);
             return ['current', 'rules'];
           }
         };
@@ -146,6 +152,54 @@ describe('bin', () => {
     };
     process.argv[2] = '-c';
     process.argv[3] = '--no-core';
+    proxyquire('../../src/bin/find', stub);
+  });
+
+  it('does not include deprecated rules by default', () => {
+    stub = {
+      '../lib/rule-finder'(specifiedFile, options) {
+        return {
+          getAllAvailableRules() {
+            assert(!options.includeDeprecated);
+            return ['current', 'rules'];
+          }
+        };
+      }
+    };
+    process.argv[2] = '-a';
+    proxyquire('../../src/bin/find', stub);
+  });
+
+  it('includes deprecated rules with --include deprecated', () => {
+    stub = {
+      '../lib/rule-finder'(specifiedFile, options) {
+        return {
+          getAllAvailableRules() {
+            assert(options.includeDeprecated);
+            return ['current', 'rules'];
+          }
+        };
+      }
+    };
+    process.argv[2] = '-a';
+    process.argv[3] = '--include=deprecated';
+    proxyquire('../../src/bin/find', stub);
+  });
+
+  it('includes deprecated rules with -i deprecated', () => {
+    stub = {
+      '../lib/rule-finder'(specifiedFile, options) {
+        return {
+          getAllAvailableRules() {
+            assert(options.includeDeprecated);
+            return ['current', 'rules'];
+          }
+        };
+      }
+    };
+    process.argv[2] = '-a';
+    process.argv[3] = '-i';
+    process.argv[4] = 'deprecated';
     proxyquire('../../src/bin/find', stub);
   });
 });


### PR DESCRIPTION
Filter out deprecated rules in `_getAllAvailableRules()` and `_getPluginRules()`.  With this change, the lists of rules displayed with the `-a` and `-u` flags will not include deprecated rules.

Breaking: The output is now different from what it was, as deprecated rules are now omitted by default.

Breaking: The `getRuleFinder()` API has changed.  Previously, it took an optional filename and an optional boolean, `noCore`.  Now, it takes the optional filename and an options object:

* `omitCore`: Exclude core rules from the output
* `includeDeprecated`: Include deprecated rules in the output

Both options default to `false` if they are not provided.

Per a review request, I've added a flag to allow deprecated rules to be included.  Adding `--include deprecated` or `-i deprecated` will include deprecated rules in the output; they're not included by default.

To make the implementation of this flag cleaner, I refactored `getRuleFinder()` to take an options object instead of a boolean as the second argument.  Adding a second boolean (`includeDeprecated`) made it a difficult interface to use.

Note that `eslint.linter.getRules()` returns an ES6 Map, which cannot be directly filtered.  Also, its `keys()` function returns an iterable, so we have to spread that into an array before we can filter it.  That's why the code is written the way it is.

To make this feature have a cleaner implementation, I also performed the following refactorings:
* Don't pass plugin rules to `_getAllAvailableRules`.  Plugin rules are now merged with core rules directly in `RuleFinder` instead.
* Rename `_getAllAvailableRules` -> `_getCoreRules` to better reflect its purpose.

I also:
* Removed the `nc` option; it isn't documented and isn't being used.

* Split some of the `find` tests into two `it` blocks.  I found that calling `proxyquire` twice in the same test wasn't doing anything, so was potentially hiding failures.

* Renamed some `rule-finder` tests to result in more consistent output.

Fixes #172 