### PR TITLE
chore(release): releasing 2.0.0 manually

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+node_modules/
+.nyc_output/
+coverage/
+src/
+test/
+*.log
+.opt-in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-find-rules",
-  "version": "1.14.3",
+  "version": "2.0.0",
   "description": "Find built-in ESLint rules you don't have in your custom config.",
   "main": "dist/lib/rule-finder.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-find-rules",
-  "version": "0.0.0-semantically-released",
+  "version": "1.14.3",
   "description": "Find built-in ESLint rules you don't have in your custom config.",
   "main": "dist/lib/rule-finder.js",
   "scripts": {
@@ -15,7 +15,7 @@
     "build": "babel src -d dist --presets es2015",
     "report-coverage": "cat ./coverage/lcov.info | node_modules/.bin/codecov",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-    "travis-after-all": "travis-after-all && npm run report-coverage && npm run semantic-release"
+    "travis-after-all": "travis-after-all && npm run report-coverage"
   },
   "bin": {
     "eslint-find-rules": "dist/bin/find.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-find-rules",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Find built-in ESLint rules you don't have in your custom config.",
   "main": "dist/lib/rule-finder.js",
   "scripts": {


### PR DESCRIPTION
Due to a hickup in the automatic release setup, we have to go back to manually releasing (at least version 2.0.0).