### PR TITLE
revert: feat(rule-finder): Default options on exported function

### DIFF
--- a/src/lib/rule-finder.js
+++ b/src/lib/rule-finder.js
@@ -80,7 +80,7 @@ function _isNotCore(rule) {
   return rule.indexOf('/') !== '-1';
 }
 
-function RuleFinder(specifiedFile, options = {}) {
+function RuleFinder(specifiedFile, options) {
   const {omitCore, includeDeprecated} = options;
   const configFile = _getConfigFile(specifiedFile);
   const config = _getConfig(configFile);
@@ -108,6 +108,6 @@ function RuleFinder(specifiedFile, options = {}) {
   this.getUnusedRules = () => getSortedRules(unusedRules);
 }
 
-module.exports = function (specifiedFile, options) {
+module.exports = function (specifiedFile, options = {}) {
   return new RuleFinder(specifiedFile, options);
 };


### PR DESCRIPTION
Per the discussion that happened after #270 was merged, this reverts the final commit on that PR so that the default `options` parameter is specified on the exported function where clients will see it, rather than on the internal and private `RuleFinder` constructor.