### PR TITLE
Prepare 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-find-rules",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Find built-in ESLint rules you don't have in your custom config.",
   "main": "dist/lib/rule-finder.js",
   "scripts": {


### PR DESCRIPTION
Making this a major because of the breaking change of its main feature and the change of the library's exposed API.

---

Proposed Changelog:

### 3.0.0 (2017-06-13)

#### Features

* By default, deprecated rules will be omitted from the output of `-a|--all-available`, `-p|--plugin` and `-u|--unused`.  If you want to report on deprecated rules as well, use the `--include=deprecated` or `-i deprecated` flag.