### PR TITLE
fix(rule-finder): dedupe plugin rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-find-rules",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Find built-in ESLint rules you don't have in your custom config.",
   "main": "dist/lib/rule-finder.js",
   "scripts": {

--- a/src/lib/rule-finder.js
+++ b/src/lib/rule-finder.js
@@ -88,10 +88,11 @@ function RuleFinder(specifiedFile, options) {
   const pluginRules = _getPluginRules(config, {includeDeprecated});
   const coreRules = _getCoreRules({includeDeprecated});
   const allRules = omitCore ? pluginRules : [...coreRules, ...pluginRules];
+  const dedupedRules = [...new Set(allRules)];
   if (omitCore) {
     currentRules = currentRules.filter(_isNotCore);
   }
-  const unusedRules = difference(allRules, currentRules); // eslint-disable-line vars-on-top
+  const unusedRules = difference(dedupedRules, currentRules); // eslint-disable-line vars-on-top
 
   // Get all the current rules instead of referring the extended files or documentation
   this.getCurrentRules = () => getSortedRules(currentRules);
@@ -103,7 +104,7 @@ function RuleFinder(specifiedFile, options) {
   this.getPluginRules = () => getSortedRules(pluginRules);
 
   // Get all the available rules instead of referring eslint and plugin packages or documentation
-  this.getAllAvailableRules = () => getSortedRules(allRules);
+  this.getAllAvailableRules = () => getSortedRules(dedupedRules);
 
   this.getUnusedRules = () => getSortedRules(unusedRules);
 }

--- a/test/fixtures/eslint-dedupe-plugin-rules.json
+++ b/test/fixtures/eslint-dedupe-plugin-rules.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./eslintrc",
+  "plugins": [
+    "plugin"
+  ],
+  "rules": {
+    "plugin/duplicate-bar-rule": [2]
+  }
+}


### PR DESCRIPTION
See #281 – including preparation for patch release.

---

Proposed Changelog:

### 3.1.1 (2017-06-18)

#### Bug Fixes

* Fixes an issue listing duplicate plugin rules when using ESLint < 4.0.

