### PR TITLE
feat(rule-finder): Report any deprecated rules in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ The intended usage is as an npm script:
 Then run it with: `$ npm run --silent eslint-find-option-rules` (the `--silent` is to silence npm output).
 
 ```
-available options are -c|--current, -a|--all-available, -p|--plugin, -u|--unused
+available options are -a|--all-available, -c|--current, -d|--deprecated, -p|--plugin, -u|--unused
 available flags are -n|--no-error, --no-core, and -i/--include deprecated
 ```
 
-By default it will error out only for `-u|--unused`,
-however if you do not want the `process` to `exit` with a `non-zero` exit code, use the `-n|--no-error` flag along with `-u|--unused`.
+By default it will error out only for `-d|--deprecated` and `-u|--unused`,
+however if you do not want the `process` to `exit` with a `non-zero` exit code, use the `-n|--no-error` flag along with `-d|--deprecated` or `-u|--unused`.
 
-By default, core rules will be included in the output of `-c|--current`, `-a|--all-available`, and `-u|--unused`.  If you want to report on plugin rules only, use the `--no-core` flag.
+By default, core rules will be included in the output of `-a|--all-available`, `-c|--current`, `-d|--deprecated`, and `-u|--unused`.  If you want to report on plugin rules only, use the `--no-core` flag.
 
 By default, deprecated rules will be omitted from the output of `-a|--all-available`, `-p|--plugin` and `-u|--unused`.  If you want to report on deprecated rules as well, use the `--include=deprecated` or `-i deprecated` flag.
 
@@ -63,7 +63,7 @@ By default, deprecated rules will be omitted from the output of `-a|--all-availa
 This is really handy in an actual config module (like [eslint-config-kentcdodds](https://github.com/kentcdodds/eslint-config-kentcdodds)) where you could also do:
 
 ```
-// available options are -c|--current, -a|--all-available, -p|--plugin, -u|--unused
+// available options are -a|--all-available, -c|--current, -d|--deprecated, -p|--plugin, -u|--unused
 eslint-find-rules --option ./index.js
 ```
 
@@ -110,6 +110,8 @@ ruleFinder.getPluginRules()
 ruleFinder.getAllAvailableRules()
 
 ruleFinder.getUnusedRules()
+
+ruleFinder.getDeprecatedRules()
 ```
 
 ### Log the difference between two config files

--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -6,6 +6,7 @@ const options = {
   getPluginRules: ['plugin', 'p'],
   getAllAvailableRules: ['all-available', 'a'],
   getUnusedRules: ['unused', 'u'],
+  getDeprecatedRules: ['deprecated', 'd'],
   n: [],
   error: ['error'],
   core: ['core'],
@@ -36,7 +37,7 @@ const ruleFinder = getRuleFinder(specifiedFile, finderOptions);
 const errorOut = argv.error && !argv.n;
 let processExitCode = argv.u && errorOut ? 1 : 0;
 
-if (!argv.c && !argv.p && !argv.a && !argv.u) {
+if (!argv.c && !argv.p && !argv.a && !argv.u && !argv.d) {
   console.log('no option provided, please provide a valid option'); // eslint-disable-line no-console
   console.log('usage:'); // eslint-disable-line no-console
   console.log('eslint-find-rules [option] <file> [flag]'); // eslint-disable-line no-console

--- a/test/bin/find.js
+++ b/test/bin/find.js
@@ -9,6 +9,7 @@ const getCurrentRules = sinon.stub().returns(['current', 'rules']);
 const getPluginRules = sinon.stub().returns(['plugin', 'rules']);
 const getAllAvailableRules = sinon.stub().returns(['all', 'available']);
 const getUnusedRules = sinon.stub().returns(['unused', 'rules']);
+const getDeprecatedRules = sinon.stub().returns(['deprecated', 'rules']);
 
 let stub;
 
@@ -20,13 +21,14 @@ describe('bin', () => {
           getCurrentRules,
           getPluginRules,
           getAllAvailableRules,
-          getUnusedRules
+          getUnusedRules,
+          getDeprecatedRules
         };
       }
     };
 
     console.log = (...args) => { // eslint-disable-line no-console
-      if (args[0].match(/(current|plugin|all-available|unused|rules found)/)) {
+      if (args[0].match(/(current|plugin|all-available|unused|deprecated|rules found)/)) {
         return;
       }
       consoleLog(...args);
@@ -115,6 +117,45 @@ describe('bin', () => {
     process.argv[3] = '--no-error';
     proxyquire('../../src/bin/find', stub);
     assert.ok(getUnusedRules.called);
+  });
+
+  it('option -d|--deprecated', () => {
+    process.exit = status => {
+      assert.equal(status, 1);
+    };
+    process.argv[2] = '-d';
+    proxyquire('../../src/bin/find', stub);
+    assert.ok(getDeprecatedRules.called);
+  });
+
+  it('options -d|--deprecated and no deprecated rules found', () => {
+    getDeprecatedRules.returns([]);
+    process.exit = status => {
+      assert.equal(status, 0);
+    };
+    process.argv[2] = '-d';
+    proxyquire('../../src/bin/find', stub);
+    assert.ok(getDeprecatedRules.called);
+  });
+
+  it('option -d|--deprecated along with -n', () => {
+    process.exit = status => {
+      assert.equal(status, 0);
+    };
+    process.argv[2] = '-d';
+    process.argv[3] = '-n';
+    proxyquire('../../src/bin/find', stub);
+    assert.ok(getDeprecatedRules.called);
+  });
+
+  it('option -d|--deprecated along with --no-error', () => {
+    process.exit = status => {
+      assert.equal(status, 0);
+    };
+    process.argv[2] = '-d';
+    process.argv[3] = '--no-error';
+    proxyquire('../../src/bin/find', stub);
+    assert.ok(getDeprecatedRules.called);
   });
 
   it('logs verbosely', () => {

--- a/test/fixtures/eslint-with-deprecated-rules.json
+++ b/test/fixtures/eslint-with-deprecated-rules.json
@@ -1,0 +1,14 @@
+{
+  "plugins": [
+    "plugin",
+    "@scope/scoped-plugin"
+  ],
+  "rules": {
+    "foo-rule": [2],
+    "old-rule": [2],
+    "plugin/foo-rule": [2],
+    "plugin/old-plugin-rule": [2],
+    "scoped-plugin/foo-rule": [2],
+    "scoped-plugin/old-plugin-rule": [2]
+  }
+}

--- a/test/lib/rule-finder.js
+++ b/test/lib/rule-finder.js
@@ -69,6 +69,7 @@ const specifiedFileRelative = './test/fixtures/eslint.json';
 const specifiedFileAbsolute = path.join(process.cwd(), specifiedFileRelative);
 const noRulesFile = path.join(process.cwd(), './test/fixtures/eslint-with-plugin-with-no-rules.json');
 const noDuplicateRulesFiles = './test/fixtures/eslint-dedupe-plugin-rules.json';
+const usingDeprecatedRulesFile = path.join(process.cwd(), './test/fixtures/eslint-with-deprecated-rules.json');
 
 describe('rule-finder', () => {
   afterEach(() => {
@@ -377,6 +378,20 @@ describe('rule-finder', () => {
     assert.deepEqual(ruleFinder.getUnusedRules(), [
       'bar-rule',
       'plugin/duplicate-foo-rule'
+    ]);
+  });
+
+  it('specifiedFile (absolute path) without deprecated rules - deprecated rules', () => {
+    const ruleFinder = getRuleFinder(specifiedFileAbsolute);
+    assert.deepEqual(ruleFinder.getDeprecatedRules(), []);
+  });
+
+  it('specifiedFile (absolute path) with deprecated rules - deprecated rules', () => {
+    const ruleFinder = getRuleFinder(usingDeprecatedRulesFile);
+    assert.deepEqual(ruleFinder.getDeprecatedRules(), [
+      'old-rule',
+      'plugin/old-plugin-rule',
+      'scoped-plugin/old-plugin-rule'
     ]);
   });
 });


### PR DESCRIPTION
Add a new `-d`/`--deprecated` option that reports any deprecated rules being used in the current configuration.

The new option respects the `--no-error` and `--no-core` options.

In order to make this work, I had to refactor everything a bit.  `_getPluginRules()` and `_getCoreRules()` now both return a `Map` of ruleName => ruleDefinition so that we can determine which rules are deprecated when we need.

With that change, I was able to move the handling of the `includeDeprecated` flag into `RuleFinder` rather than passing it off to the `_get*Rules` functions.

Fixes #188 

h/t @casto101 and @cseidholz for pairing on this with me.