### PR TITLE
fix(exit-code): Exit with status 1 when there are deprecated rules

### DIFF
--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -12,6 +12,7 @@ const options = {
   core: ['core'],
   verbose: ['verbose', 'v']
 };
+const optionsThatError = ['getUnusedRules', 'getDeprecatedRules'];
 
 const argv = require('yargs')
   .boolean(Object.keys(options))
@@ -35,7 +36,7 @@ const finderOptions = {
 };
 const ruleFinder = getRuleFinder(specifiedFile, finderOptions);
 const errorOut = argv.error && !argv.n;
-let processExitCode = argv.u && errorOut ? 1 : 0;
+let processExitCode = 0;
 
 if (!argv.c && !argv.p && !argv.a && !argv.u && !argv.d) {
   console.log('no option provided, please provide a valid option'); // eslint-disable-line no-console
@@ -63,12 +64,11 @@ Object.keys(options).forEach(option => {
         cli.push(rules);
       }
       cli.write();
-    } else /* istanbul ignore next */ if (option === 'getUnusedRules') {
-      processExitCode = 0;
+      if (errorOut && optionsThatError.indexOf(option) !== -1) {
+        processExitCode = 1;
+      }
     }
   }
 });
 
-if (processExitCode) {
-  process.exit(processExitCode);
-}
+process.exit(processExitCode);

--- a/test/bin/find.js
+++ b/test/bin/find.js
@@ -12,6 +12,7 @@ const getUnusedRules = sinon.stub().returns(['unused', 'rules']);
 const getDeprecatedRules = sinon.stub().returns(['deprecated', 'rules']);
 
 let stub;
+let exitStatus;
 
 describe('bin', () => {
   beforeEach(() => {
@@ -33,7 +34,10 @@ describe('bin', () => {
       }
       consoleLog(...args);
     };
-    process.exit = function () {}; // Noop
+    exitStatus = null;
+    process.exit = status => {
+      exitStatus = status;
+    };
     process.argv = process.argv.slice(0, 2);
   });
 
@@ -63,12 +67,14 @@ describe('bin', () => {
     process.argv[2] = '-c';
     proxyquire('../../src/bin/find', stub);
     assert.ok(getCurrentRules.called);
+    assert.equal(exitStatus, 0);
   });
 
   it('option -p|--plugin', () => {
     process.argv[2] = '-p';
     proxyquire('../../src/bin/find', stub);
     assert.ok(getPluginRules.called);
+    assert.equal(exitStatus, 0);
   });
 
   it('option -a|--all-available', () => {
@@ -78,84 +84,69 @@ describe('bin', () => {
     process.argv[2] = '--all-available';
     proxyquire('../../src/bin/find', stub);
     assert.ok(getAllAvailableRules.called);
+    assert.equal(exitStatus, 0);
   });
 
   it('option -u|--unused', () => {
-    process.exit = status => {
-      assert.equal(status, 1);
-    };
     process.argv[2] = '-u';
     proxyquire('../../src/bin/find', stub);
     assert.ok(getUnusedRules.called);
+    assert.equal(exitStatus, 1);
   });
 
   it('options -u|--unused and no unused rules found', () => {
     getUnusedRules.returns([]);
-    process.exit = status => {
-      assert.equal(status, 0);
-    };
     process.argv[2] = '-u';
     proxyquire('../../src/bin/find', stub);
     assert.ok(getUnusedRules.called);
+    assert.equal(exitStatus, 0);
   });
 
   it('option -u|--unused along with -n', () => {
-    process.exit = status => {
-      assert.equal(status, 0);
-    };
     process.argv[2] = '-u';
     process.argv[3] = '-n';
     proxyquire('../../src/bin/find', stub);
     assert.ok(getUnusedRules.called);
+    assert.equal(exitStatus, 0);
   });
 
   it('option -u|--unused along with --no-error', () => {
-    process.exit = status => {
-      assert.equal(status, 0);
-    };
     process.argv[2] = '-u';
     process.argv[3] = '--no-error';
     proxyquire('../../src/bin/find', stub);
     assert.ok(getUnusedRules.called);
+    assert.equal(exitStatus, 0);
   });
 
   it('option -d|--deprecated', () => {
-    process.exit = status => {
-      assert.equal(status, 1);
-    };
     process.argv[2] = '-d';
     proxyquire('../../src/bin/find', stub);
     assert.ok(getDeprecatedRules.called);
+    assert.equal(exitStatus, 1);
   });
 
   it('options -d|--deprecated and no deprecated rules found', () => {
     getDeprecatedRules.returns([]);
-    process.exit = status => {
-      assert.equal(status, 0);
-    };
     process.argv[2] = '-d';
     proxyquire('../../src/bin/find', stub);
     assert.ok(getDeprecatedRules.called);
+    assert.equal(exitStatus, 0);
   });
 
   it('option -d|--deprecated along with -n', () => {
-    process.exit = status => {
-      assert.equal(status, 0);
-    };
     process.argv[2] = '-d';
     process.argv[3] = '-n';
     proxyquire('../../src/bin/find', stub);
     assert.ok(getDeprecatedRules.called);
+    assert.equal(exitStatus, 0);
   });
 
   it('option -d|--deprecated along with --no-error', () => {
-    process.exit = status => {
-      assert.equal(status, 0);
-    };
     process.argv[2] = '-d';
     process.argv[3] = '--no-error';
     proxyquire('../../src/bin/find', stub);
     assert.ok(getDeprecatedRules.called);
+    assert.equal(exitStatus, 0);
   });
 
   it('logs verbosely', () => {


### PR DESCRIPTION
In #286, I added support for reporting on deprecated rules.  According to the documentation and tests I wrote, eslint-find-rules is supposed to exit with code 1 when there are deprecated rules (unless the `--no-error` flag is also provided).  However, in real usage, this didn't happen.

I discovered that the exit status assertions in the tests were not actually being called in all cases, resulting in the tests passing incorrectly.  Looks like I forgot to make sure that the test failed for the right reason in this case.  Mea culpa :-(.

I made the following changes:
- Modify the tests to always capture the process exit code
- Add assertions against the captured exit code where necessary
- Re-work how `processExitCode` is managed in the code