### PR TITLE
Rectify 3.2.0 version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-find-rules",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Find built-in ESLint rules you don't have in your custom config.",
   "main": "dist/lib/rule-finder.js",
   "scripts": {


### PR DESCRIPTION
This PR let's `master` catch up with [the already released version](https://github.com/sarbbottam/eslint-find-rules/releases/tag/v3.2.0).
