### PR TITLE
Prepare 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-find-rules",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Find built-in ESLint rules you don't have in your custom config.",
   "main": "dist/lib/rule-finder.js",
   "scripts": {


### PR DESCRIPTION
Proposed Changelog:

### 3.2.1 (2018-02-23)

#### Bug Fixes

* Correctly exit eslint-find-rules with code 1 when reporting on deprecated rules ( `--include=deprecated` or `-i deprecated`) and there are deprecated rules (unless the `--no-error` flag is also provided).