### PR TITLE
feat(check-eslint): Check for ESLint peerDependency being met

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cliui": "^3.2.0",
     "eslint-rule-documentation": "^1.0.0",
     "path-is-absolute": "^1.0.1",
+    "semver": "^5.5.0",
     "which": "^1.2.8",
     "window-size": "0.3.0",
     "yargs": "^8.0.1"

--- a/src/bin/diff.js
+++ b/src/bin/diff.js
@@ -2,95 +2,107 @@
 
 'use strict';
 
-const path = require('path');
-const argv = require('yargs')
-  .boolean('verbose')
-  .alias('v', 'verbose')
-  .argv;
+const checkEslint = require('../lib/check-eslint');
 
-const cli = require('../lib/cli-util');
+if (checkEslint.check() === false) {
+  console.log('Could not load ESLint');
+  console.log(
+    'eslint-find-rules requires ESLint ' +
+    checkEslint.requiredVersion
+  );
+  process.exit(1);
+} else {
+  const path = require('path');
+  const argv = require('yargs')
+    .boolean('verbose')
+    .alias('v', 'verbose')
+    .argv;
 
-const getRuleFinder = require('../lib/rule-finder');
-const arrayDifference = require('../lib/array-diff');
-const objectDifference = require('../lib/object-diff');
-const getSortedRules = require('../lib/sort-rules');
-const flattenRulesDiff = require('../lib/flatten-rules-diff');
-const stringifyRuleConfig = require('../lib/stringify-rule-config');
+  const cli = require('../lib/cli-util');
 
-const files = [argv._[0], argv._[1]];
-const collectedRules = getFilesToCompare(files).map(compareConfigs);
+  const getRuleFinder = require('../lib/rule-finder');
+  const arrayDifference = require('../lib/array-diff');
+  const objectDifference = require('../lib/object-diff');
+  const getSortedRules = require('../lib/sort-rules');
+  const flattenRulesDiff = require('../lib/flatten-rules-diff');
+  const stringifyRuleConfig = require('../lib/stringify-rule-config');
 
-const rulesCount = collectedRules.reduce(
-  (prev, curr) => {
-    return prev + (curr && curr.rules ? curr.rules.length : /* istanbul ignore next */ 0);
-  }, 0);
+  const files = [argv._[0], argv._[1]];
+  const collectedRules = getFilesToCompare(files).map(compareConfigs);
 
-/* istanbul ignore else */
-if (argv.verbose || rulesCount) {
-  cli.push('\ndiff rules\n' + rulesCount + ' rules differ\n');
-}
+  const rulesCount = collectedRules.reduce(
+    (prev, curr) => {
+      return prev + (curr && curr.rules ? curr.rules.length : /* istanbul ignore next */ 0);
+    }, 0);
 
-/* istanbul ignore else */
-if (rulesCount) {
-  collectedRules.forEach(diff => {
-    let rules = diff.rules;
-
-    /* istanbul ignore if */
-    if (rules.length < 1) {
-      return;
-    }
-
-    if (argv.verbose) {
-      rules = flattenRulesDiff(rules).map(stringifyRuleConfig);
-      rules.unshift([], diff.config1, diff.config2);
-    } else {
-      cli.push('\nin ' + diff.config1 + ' but not in ' + diff.config2 + ':\n');
-    }
-
-    cli.push(rules, argv.verbose ? 3 : 0);
-  });
-}
-
-cli.write();
-
-function getFilesToCompare(allFiles) {
-  const filesToCompare = [allFiles];
-
-  if (!argv.verbose) {
-    // In non-verbose output mode, compare a to b
-    // and b to a afterwards, to obtain ALL differences
-    // accross those files, but grouped
-    filesToCompare.push([].concat(allFiles).reverse());
+  /* istanbul ignore else */
+  if (argv.verbose || rulesCount) {
+    cli.push('\ndiff rules\n' + rulesCount + ' rules differ\n');
   }
 
-  return filesToCompare;
-}
+  /* istanbul ignore else */
+  if (rulesCount) {
+    collectedRules.forEach(diff => {
+      let rules = diff.rules;
 
-function compareConfigs(currentFiles) {
-  return {
-    config1: path.basename(currentFiles[0]),
-    config2: path.basename(currentFiles[1]),
-    rules: rulesDifference(
-      getRuleFinder(currentFiles[0]),
-      getRuleFinder(currentFiles[1])
-    )
-  };
-}
+      /* istanbul ignore if */
+      if (rules.length < 1) {
+        return;
+      }
 
-function rulesDifference(a, b) {
-  if (argv.verbose) {
+      if (argv.verbose) {
+        rules = flattenRulesDiff(rules).map(stringifyRuleConfig);
+        rules.unshift([], diff.config1, diff.config2);
+      } else {
+        cli.push('\nin ' + diff.config1 + ' but not in ' + diff.config2 + ':\n');
+      }
+
+      cli.push(rules, argv.verbose ? 3 : 0);
+    });
+  }
+
+  cli.write();
+  process.exit(0);
+
+  function getFilesToCompare(allFiles) {
+    const filesToCompare = [allFiles];
+
+    if (!argv.verbose) {
+      // In non-verbose output mode, compare a to b
+      // and b to a afterwards, to obtain ALL differences
+      // accross those files, but grouped
+      filesToCompare.push([].concat(allFiles).reverse());
+    }
+
+    return filesToCompare;
+  }
+
+  function compareConfigs(currentFiles) {
+    return {
+      config1: path.basename(currentFiles[0]),
+      config2: path.basename(currentFiles[1]),
+      rules: rulesDifference(
+        getRuleFinder(currentFiles[0]),
+        getRuleFinder(currentFiles[1])
+      )
+    };
+  }
+
+  function rulesDifference(a, b) {
+    if (argv.verbose) {
+      return getSortedRules(
+        objectDifference(
+          a.getCurrentRulesDetailed(),
+          b.getCurrentRulesDetailed()
+        )
+      );
+    }
+
     return getSortedRules(
-      objectDifference(
-        a.getCurrentRulesDetailed(),
-        b.getCurrentRulesDetailed()
+      arrayDifference(
+        a.getCurrentRules(),
+        b.getCurrentRules()
       )
     );
   }
-
-  return getSortedRules(
-    arrayDifference(
-      a.getCurrentRules(),
-      b.getCurrentRules()
-    )
-  );
 }

--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -1,74 +1,86 @@
 #!/usr/bin/env node
 
 'use strict';
-const options = {
-  getCurrentRules: ['current', 'c'],
-  getPluginRules: ['plugin', 'p'],
-  getAllAvailableRules: ['all-available', 'a'],
-  getUnusedRules: ['unused', 'u'],
-  getDeprecatedRules: ['deprecated', 'd'],
-  n: [],
-  error: ['error'],
-  core: ['core'],
-  verbose: ['verbose', 'v']
-};
-const optionsThatError = ['getUnusedRules', 'getDeprecatedRules'];
 
-const argv = require('yargs')
-  .boolean(Object.keys(options))
-  .alias(options)
-  .option('include', {
-    alias: 'i',
-    choices: ['deprecated'],
-    type: 'string'
-  })
-  .default('error', true)
-  .default('core', true)
-  .argv;
-const getRuleURI = require('eslint-rule-documentation');
-const getRuleFinder = require('../lib/rule-finder');
-const cli = require('../lib/cli-util');
+const checkEslint = require('../lib/check-eslint');
 
-const specifiedFile = argv._[0];
-const finderOptions = {
-  omitCore: !argv.core,
-  includeDeprecated: argv.include === 'deprecated'
-};
-const ruleFinder = getRuleFinder(specifiedFile, finderOptions);
-const errorOut = argv.error && !argv.n;
-let processExitCode = 0;
+if (checkEslint.check() === false) {
+  console.log('Could not load ESLint');
+  console.log(
+    'eslint-find-rules requires ESLint ' +
+    checkEslint.requiredVersion
+  );
+  process.exit(1);
+} else {
+  const options = {
+    getCurrentRules: ['current', 'c'],
+    getPluginRules: ['plugin', 'p'],
+    getAllAvailableRules: ['all-available', 'a'],
+    getUnusedRules: ['unused', 'u'],
+    getDeprecatedRules: ['deprecated', 'd'],
+    n: [],
+    error: ['error'],
+    core: ['core'],
+    verbose: ['verbose', 'v']
+  };
+  const optionsThatError = ['getUnusedRules', 'getDeprecatedRules'];
 
-if (!argv.c && !argv.p && !argv.a && !argv.u && !argv.d) {
-  console.log('no option provided, please provide a valid option'); // eslint-disable-line no-console
-  console.log('usage:'); // eslint-disable-line no-console
-  console.log('eslint-find-rules [option] <file> [flag]'); // eslint-disable-line no-console
-  process.exit(0);
-}
+  const argv = require('yargs')
+    .boolean(Object.keys(options))
+    .alias(options)
+    .option('include', {
+      alias: 'i',
+      choices: ['deprecated'],
+      type: 'string'
+    })
+    .default('error', true)
+    .default('core', true)
+    .argv;
+  const getRuleURI = require('eslint-rule-documentation');
+  const getRuleFinder = require('../lib/rule-finder');
+  const cli = require('../lib/cli-util');
 
-Object.keys(options).forEach(option => {
-  let rules;
-  const ruleFinderMethod = ruleFinder[option];
-  if (argv[option] && ruleFinderMethod) {
-    rules = ruleFinderMethod();
-    if (argv.verbose) {
-      cli.push('\n' + options[option][0] + ' rules\n' + rules.length + ' rules found\n');
-    }
-    if (rules.length > 0) {
-      if (argv.verbose) {
-        rules = rules
-          .map(rule => [rule, getRuleURI(rule).url])
-          .reduce((all, single) => all.concat(single));
-        cli.push(rules, 2, false);
-      } else {
-        cli.push('\n' + options[option][0] + ' rules\n');
-        cli.push(rules);
-      }
-      cli.write();
-      if (errorOut && optionsThatError.indexOf(option) !== -1) {
-        processExitCode = 1;
-      }
-    }
+  const specifiedFile = argv._[0];
+  const finderOptions = {
+    omitCore: !argv.core,
+    includeDeprecated: argv.include === 'deprecated'
+  };
+  const ruleFinder = getRuleFinder(specifiedFile, finderOptions);
+  const errorOut = argv.error && !argv.n;
+  let processExitCode = 0;
+
+  if (!argv.c && !argv.p && !argv.a && !argv.u && !argv.d) {
+    console.log('no option provided, please provide a valid option'); // eslint-disable-line no-console
+    console.log('usage:'); // eslint-disable-line no-console
+    console.log('eslint-find-rules [option] <file> [flag]'); // eslint-disable-line no-console
+    process.exit(0);
   }
-});
 
-process.exit(processExitCode);
+  Object.keys(options).forEach(option => {
+    let rules;
+    const ruleFinderMethod = ruleFinder[option];
+    if (argv[option] && ruleFinderMethod) {
+      rules = ruleFinderMethod();
+      if (argv.verbose) {
+        cli.push('\n' + options[option][0] + ' rules\n' + rules.length + ' rules found\n');
+      }
+      if (rules.length > 0) {
+        if (argv.verbose) {
+          rules = rules
+            .map(rule => [rule, getRuleURI(rule).url])
+            .reduce((all, single) => all.concat(single));
+          cli.push(rules, 2, false);
+        } else {
+          cli.push('\n' + options[option][0] + ' rules\n');
+          cli.push(rules);
+        }
+        cli.write();
+        if (errorOut && optionsThatError.indexOf(option) !== -1) {
+          processExitCode = 1;
+        }
+      }
+    }
+  });
+
+  process.exit(processExitCode);
+}

--- a/src/lib/check-eslint.js
+++ b/src/lib/check-eslint.js
@@ -1,0 +1,48 @@
+const path = require('path');
+const semver = require('semver');
+
+const requiredVersion = getRequiredEslintVersion();
+
+function getEslint() {
+  try {
+    return require('eslint');
+  } catch (err) {
+    /* istanbul ignore if */
+    if (err.code !== 'MODULE_NOT_FOUND') {
+      throw err;
+    }
+  }
+  return null;
+}
+
+function getEslintVersion() {
+  const eslint = getEslint();
+
+  if (eslint === null ||
+    !eslint.CLIEngine) {
+    return null;
+  }
+
+  return eslint.CLIEngine.version;
+}
+
+function getRequiredEslintVersion() {
+  const jsonPath = path.resolve(__dirname, '..', '..', 'package.json');
+  const packageJson = require(jsonPath);
+  return packageJson.peerDependencies.eslint;
+}
+
+function check() {
+  const foundVersion = getEslintVersion();
+
+  if (!semver.valid(foundVersion)) {
+    return false;
+  }
+
+  return semver.satisfies(foundVersion, requiredVersion);
+}
+
+module.exports = {
+  check,
+  requiredVersion
+};

--- a/test/bin/diff.js
+++ b/test/bin/diff.js
@@ -3,6 +3,7 @@ const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 
 const consoleLog = console.log; // eslint-disable-line no-console
+const processExit = process.exit;
 
 const stub = {
   '../lib/rule-finder'() {
@@ -14,22 +15,45 @@ const stub = {
   '../lib/array-diff': sinon.stub().returns(['diff']),
   '../lib/object-diff': sinon.stub().returns([{'test-rule': {config1: 'foo-config', config2: 'bar-config'}}])
 };
+let exitStatus;
 
 describe('diff', () => {
   beforeEach(() => {
     process.argv = process.argv.slice(0, 2);
     sinon.stub(console, 'log').callsFake((...args) => {
       // Print out everything but the test target's output
-      if (!args[0].match(/diff/)) {
+      if (!args[0].match(/(diff|(Could not load|requires) ESLint)/)) {
         consoleLog(...args);
       }
     });
+    exitStatus = null;
+    process.exit = status => {
+      exitStatus = status;
+    };
   });
 
   afterEach(() => {
     console.log.restore(); // eslint-disable-line no-console
+    process.exit = processExit;
     // purge yargs cache
     delete require.cache[require.resolve('yargs')];
+  });
+
+  it('checks for eslint', () => {
+    proxyquire('../../src/bin/diff', {
+      '../lib/check-eslint': {
+        check: () => false,
+        requiredVersion: '1.2.3'
+      }
+    });
+    assert.ok(
+      console.log.calledWith( // eslint-disable-line no-console
+        sinon.match(
+          /(Could not load|requires) ESLint/
+        )
+      )
+    );
+    assert.equal(exitStatus, 1);
   });
 
   it('logs diff', () => {
@@ -43,6 +67,7 @@ describe('diff', () => {
         )
       )
     );
+    assert.equal(exitStatus, 0);
   });
 
   it('logs diff verbosely', () => {
@@ -57,5 +82,6 @@ describe('diff', () => {
         )
       )
     );
+    assert.equal(exitStatus, 0);
   });
 });

--- a/test/bin/find.js
+++ b/test/bin/find.js
@@ -48,6 +48,27 @@ describe('bin', () => {
     delete require.cache[require.resolve('yargs')];
   });
 
+  it('checks for eslint', () => {
+    let callCount = 0;
+    console.log = (...args) => { // eslint-disable-line no-console
+      callCount += 1;
+      if (args[0].match(
+        /(Could not load|requires) ESLint/)
+      ) {
+        return;
+      }
+      consoleLog(...args);
+    };
+    proxyquire('../../src/bin/find', {
+      '../lib/check-eslint': {
+        check: () => false,
+        requiredVersion: '1.2.3'
+      }
+    });
+    assert.equal(callCount, 2);
+    assert.equal(exitStatus, 1);
+  });
+
   it('no option', () => {
     let callCount = 0;
     console.log = (...args) => { // eslint-disable-line no-console

--- a/test/lib/check-eslint.js
+++ b/test/lib/check-eslint.js
@@ -1,0 +1,36 @@
+const assert = require('assert');
+const path = require('path');
+const proxyquire = require('proxyquire');
+
+const jsonPath = path.resolve(process.cwd(), 'package.json');
+let stub;
+
+describe('check-eslint', () => {
+  beforeEach(() => {
+    stub = {
+      eslint: null,
+      [jsonPath]: {
+        peerDependencies: {
+          eslint: '^1.2.3'
+        }
+      }
+    };
+  });
+
+  it('reports absence of eslint', () => {
+    const checkEslint = proxyquire('../../src/lib/check-eslint', stub);
+    assert.equal(checkEslint.check(), false);
+  });
+
+  it('reports insufficient eslint installation', () => {
+    stub.eslint = {CLIEngine: {version: '0.0.0'}};
+    const checkEslint = proxyquire('../../src/lib/check-eslint', stub);
+    assert.equal(checkEslint.check(), false);
+  });
+
+  it('reports satisfying eslint installation', () => {
+    stub.eslint = {CLIEngine: {version: '1.3.4'}};
+    const checkEslint = proxyquire('../../src/lib/check-eslint', stub);
+    assert.ok(checkEslint.check(), true);
+  });
+});


### PR DESCRIPTION
Before anything else, checks that ESLint is installed and present in a sufficient version, exit with code 1 otherwise.

_This is currently wip — I just threw it together this evening and wanted to collect some opinions._

There are some minor issues reported by the linter: almost the whole content of `bin/diff.js` moved into the eslint-check's else-branch and with it all the function declarations. I think that whole thing should be refactored soon anyways, so I'd think it's not that big of a deal ...

---

I planned to make use of `yargs` feature to print out usage instructions too (in case of insufficient arguments), but that would be out of scope for this PR.

---

PS: If not already known, appending `?w=0` to the url for the commits of this PR (like [here](https://github.com/sarbbottam/eslint-find-rules/pull/290/commits/214760535f4eb082f62d5b1ef1fc1f86ff44d0db?w=1)) ignores whitespace changes and makes this PR much more easy to read. 