### PR TITLE
Prepare 3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-find-rules",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Find built-in ESLint rules you don't have in your custom config.",
   "main": "dist/lib/rule-finder.js",
   "scripts": {


### PR DESCRIPTION
Proposed Changelog:

### 3.2.2 (2018-03-14)

#### Bug Fixes

* Output is now properly collected before printed on screen, preventing duplication when multiple options (like `--plugin`, `--unused`) are specified.
