### PR TITLE
fix(cli): Prevent empty output

### DIFF
--- a/src/lib/cli-util.js
+++ b/src/lib/cli-util.js
@@ -34,7 +34,12 @@ function push(output, columns, uniformColWidths) {
 function write(logger) {
   const _logger = logger || console;
   const _log = _logger.log || /* istanbul ignore next */ console.log; // eslint-disable-line no-console
-  _log(ui.toString());
+  const output = ui.toString();
+
+  // Only log when there is something to show
+  if (output.length > 0) {
+    _log(output);
+  }
 }
 
 function getOutputCellMapper(widths, padding) {

--- a/test/lib/cli-util.js
+++ b/test/lib/cli-util.js
@@ -19,6 +19,17 @@ describe('cli-util', () => {
     loggerStub.log.restore();
   });
 
+  it('does not print empty lines', () => {
+    const cli = proxyquire('../../src/lib/cli-util', moduleStub);
+
+    // Nothing pushed to cli
+    cli.write(loggerStub);
+
+    assert.ok(
+      loggerStub.log.called === false
+    );
+  });
+
   it('prints out single lines', () => {
     const cli = proxyquire('../../src/lib/cli-util', moduleStub);
 


### PR DESCRIPTION
`eslint-find-rules --unused rules.js` should not output an empty line when there are no unused rules.