### PR TITLE
Prepare 3.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-find-rules",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Find built-in ESLint rules you don't have in your custom config.",
   "main": "dist/lib/rule-finder.js",
   "scripts": {


### PR DESCRIPTION
Sorry, I was on vacation for a couple of days.  
Will merge and manually publish within the next days, when approved.

---

Proposed Changelog:

### 3.2.3 (2018-04-13)

#### Bug Fixes

* Prevent empty output for option `--unused` when there are no unused rules.
