### PR TITLE
fix(rule-finder): Support scoped packages with dashes

### DIFF
--- a/src/lib/normalize-plugin-name.js
+++ b/src/lib/normalize-plugin-name.js
@@ -1,0 +1,111 @@
+/* istanbul ignore file: ignore from coverage because it varies per eslint version */
+
+/* eslint-disable import/no-unresolved */
+
+let eslintNaming;
+
+function _getNormalizer() {
+  if (eslintNaming) {
+    return eslintNaming;
+  }
+
+  const eslintVersionFunctions = [
+    // eslint 6
+    function () {
+      const normalizer = require('eslint/lib/cli-engine/naming');
+
+      return {
+        normalizePackageName: normalizer.normalizePackageName,
+        getShorthandName: normalizer.getShorthandName
+      };
+    },
+    // eslint 5
+    function () {
+      const normalizer = require('eslint/lib/util/naming');
+
+      return {
+        normalizePackageName: normalizer.normalizePackageName,
+        getShorthandName: normalizer.getShorthandName
+      };
+    },
+    // eslint 4
+    function () {
+      const normalizer = require('eslint/lib/util/naming');
+
+      return {
+        normalizePackageName: normalizer.normalizePackageName,
+        getShorthandName: normalizer.removeNamespaceFromTerm
+      };
+    },
+    // eslint 3
+    function () {
+      const normalizer = require('eslint/lib/config/plugins');
+
+      const PLUGIN_NAME_PREFIX = 'eslint-plugin-';
+
+      function parsePluginName(pluginName) {
+        const pluginNamespace = normalizer.getNamespace(pluginName);
+        const pluginNameWithoutNamespace = normalizer.removeNamespace(pluginName);
+        const pluginNameWithoutPrefix = normalizer.removePrefix(pluginNameWithoutNamespace);
+
+        return {
+          pluginNamespace,
+          pluginNameWithoutPrefix
+        };
+      }
+
+      function normalizePackageName(pluginName) {
+        const sections = parsePluginName(pluginName);
+        const longName = sections.pluginNamespace +
+          PLUGIN_NAME_PREFIX +
+          sections.pluginNameWithoutPrefix;
+
+        return longName;
+      }
+
+      function getShorthandName(pluginName) {
+        const sections = parsePluginName(pluginName);
+        const shortName = sections.pluginNamespace + sections.pluginNameWithoutPrefix;
+
+        return shortName;
+      }
+
+      return {
+        normalizePackageName,
+        getShorthandName
+      };
+    }
+  ];
+
+  for (const tryEslintVersion of eslintVersionFunctions) {
+    try {
+      const normalizer = tryEslintVersion();
+
+      if (
+        typeof normalizer.normalizePackageName === 'function' &&
+        typeof normalizer.getShorthandName === 'function'
+      ) {
+        eslintNaming = {
+          normalizePackageName: normalizer.normalizePackageName,
+          getShorthandName: normalizer.getShorthandName
+        };
+
+        return eslintNaming;
+      }
+    } catch (err) {
+    }
+  }
+
+  throw new Error('eslint naming functions not found');
+}
+
+function normalizePluginName(name) {
+  const normalizer = _getNormalizer();
+
+  const module = normalizer.normalizePackageName(name, 'eslint-plugin');
+  const prefix = normalizer.getShorthandName(name, 'eslint-plugin');
+
+  return {module, prefix};
+}
+
+module.exports = normalizePluginName;

--- a/src/lib/normalize-plugin-name.js
+++ b/src/lib/normalize-plugin-name.js
@@ -10,7 +10,16 @@ function _getNormalizer() {
   }
 
   const eslintVersionFunctions = [
-    // eslint 6
+    // eslint >= 6.1.0
+    function () {
+      const normalizer = require('eslint/lib/shared/naming');
+
+      return {
+        normalizePackageName: normalizer.normalizePackageName,
+        getShorthandName: normalizer.getShorthandName
+      };
+    },
+    // eslint 6.0.0 - 6.0.1
     function () {
       const normalizer = require('eslint/lib/cli-engine/naming');
 

--- a/src/lib/rule-finder.js
+++ b/src/lib/rule-finder.js
@@ -5,6 +5,7 @@ const glob = require('glob');
 const isAbsolute = require('path-is-absolute');
 const difference = require('./array-diff');
 const getSortedRules = require('./sort-rules');
+const normalizePluginName = require('./normalize-plugin-name');
 
 function _getConfigFile(specifiedFile) {
   if (specifiedFile) {
@@ -39,34 +40,6 @@ function _getCurrentNamesRules(config) {
   return Object.keys(config.rules);
 }
 
-function _normalizePluginName(name) {
-  const scopedRegex = /(@[^/]+)(\/(.+))?/;
-  const match = scopedRegex.exec(name);
-
-  /* istanbul ignore if: cannot test this branch in eslint <5  */
-  if (match) {
-    if (match[3]) {
-      // @scoped/name => @scope/eslint-plugin-name
-      return {
-        module: `${match[1]}/eslint-plugin-${match[3]}`,
-        prefix: `${match[1]}/${match[3]}`
-      };
-    }
-
-    // @scoped => @scope/eslint-plugin
-    return {
-      module: `${match[1]}/eslint-plugin`,
-      prefix: match[1]
-    };
-  }
-
-  // Name => eslint-plugin-name
-  return {
-    module: `eslint-plugin-${name}`,
-    prefix: name
-  };
-}
-
 function _isDeprecated(rule) {
   return rule && rule.meta && rule.meta.deprecated;
 }
@@ -81,7 +54,7 @@ function _getPluginRules(config) {
   /* istanbul ignore else */
   if (plugins) {
     plugins.forEach(plugin => {
-      const normalized = _normalizePluginName(plugin);
+      const normalized = normalizePluginName(plugin);
       const pluginConfig = require(normalized.module);  // eslint-disable-line import/no-dynamic-require
       const rules = pluginConfig.rules === undefined ? {} : pluginConfig.rules;
 

--- a/test/fixtures/v5+/eslint-with-deprecated-rules.json
+++ b/test/fixtures/v5+/eslint-with-deprecated-rules.json
@@ -2,16 +2,27 @@
   "plugins": [
     "plugin",
     "@scope/scoped-plugin",
-    "@scope"
+    "@scope",
+    "@scope-with-dash/scoped-with-dash-plugin",
+    "@scope-with-dash/eslint-plugin"
   ],
   "rules": {
     "foo-rule": [2],
     "old-rule": [2],
+
     "plugin/foo-rule": [2],
     "plugin/old-plugin-rule": [2],
+
     "@scope/scoped-plugin/foo-rule": [2],
     "@scope/scoped-plugin/old-plugin-rule": [2],
+
     "@scope/foo-rule": [2],
-    "@scope/old-plugin-rule": [2]
+    "@scope/old-plugin-rule": [2],
+
+    "@scope-with-dash/scoped-with-dash-plugin/foo-rule": [2],
+    "@scope-with-dash/scoped-with-dash-plugin/old-plugin-rule": [2],
+
+    "@scope-with-dash/foo-rule": [2],
+    "@scope-with-dash/old-plugin-rule": [2]
   }
 }

--- a/test/fixtures/v5+/eslint.json
+++ b/test/fixtures/v5+/eslint.json
@@ -3,10 +3,15 @@
   "plugins": [
     "plugin",
     "@scope/scoped-plugin",
-    "@scope"
+    "@scope",
+    "@scope-with-dash/scoped-with-dash-plugin",
+    "@scope-with-dash/eslint-plugin"
   ],
   "rules": {
     "@scope/scoped-plugin/foo-rule": [2],
-    "@scope/foo-rule": [2]
+    "@scope/foo-rule": [2],
+
+    "@scope-with-dash/scoped-with-dash-plugin/foo-rule": [2],
+    "@scope-with-dash/foo-rule": [2]
   }
 }

--- a/test/lib/rule-finder.js
+++ b/test/lib/rule-finder.js
@@ -173,7 +173,10 @@ const noRulesFile = path.join(process.cwd(), `./test/fixtures/${eslintVersion}/e
 const noDuplicateRulesFiles = `./test/fixtures/${eslintVersion}/eslint-dedupe-plugin-rules.json`;
 const usingDeprecatedRulesFile = path.join(process.cwd(), `./test/fixtures/${eslintVersion}/eslint-with-deprecated-rules.json`);
 
-describe('rule-finder', () => {
+describe('rule-finder', function() {
+  // increase timeout because proxyquire adds a significant delay
+  this.timeout(5000);
+
   afterEach(() => {
     process.cwd = processCwd;
   });

--- a/test/lib/rule-finder.js
+++ b/test/lib/rule-finder.js
@@ -91,6 +91,24 @@ const getRuleFinder = proxyquire('../../src/lib/rule-finder', {
     },
     '@noCallThru': true,
     '@global': true
+  },
+  '@scope-with-dash/eslint-plugin-scoped-with-dash-plugin': {
+    rules: {
+      'foo-rule': {},
+      'old-plugin-rule': {meta: {deprecated: true}},
+      'bar-rule': {}
+    },
+    '@noCallThru': true,
+    '@global': true
+  },
+  '@scope-with-dash/eslint-plugin': {
+    rules: {
+      'foo-rule': {},
+      'old-plugin-rule': {meta: {deprecated: true}},
+      'bar-rule': {}
+    },
+    '@noCallThru': true,
+    '@global': true
   }
 });
 
@@ -223,6 +241,8 @@ describe('rule-finder', () => {
   it('specifiedFile (relative path) - unused rules', () => {
     const ruleFinder = getRuleFinder(specifiedFileRelative);
     assertDeepEqual(ruleFinder.getUnusedRules(), [
+      '@scope-with-dash/bar-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/bar-rule',
       '@scope/bar-rule',
       '@scope/scoped-plugin/bar-rule',
       'baz-rule',
@@ -235,6 +255,10 @@ describe('rule-finder', () => {
   it('specifiedFile (relative path) - unused rules including deprecated', () => {
     const ruleFinder = getRuleFinder(specifiedFileRelative, {includeDeprecated: true});
     assertDeepEqual(ruleFinder.getUnusedRules(), [
+      '@scope-with-dash/bar-rule',
+      '@scope-with-dash/old-plugin-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/bar-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/old-plugin-rule',
       '@scope/bar-rule',
       '@scope/old-plugin-rule',
       '@scope/scoped-plugin/bar-rule',
@@ -251,6 +275,8 @@ describe('rule-finder', () => {
   it('specifiedFile (relative path) - current rules', () => {
     const ruleFinder = getRuleFinder(specifiedFileRelative);
     assertDeepEqual(ruleFinder.getCurrentRules(), [
+      '@scope-with-dash/foo-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/foo-rule',
       '@scope/foo-rule',
       '@scope/scoped-plugin/foo-rule',
       'bar-rule',
@@ -261,6 +287,8 @@ describe('rule-finder', () => {
   it('specifiedFile (relative path) - current rule config', () => {
     const ruleFinder = getRuleFinder(specifiedFileRelative);
     assertDeepEqual(ruleFinder.getCurrentRulesDetailed(), {
+      '@scope-with-dash/foo-rule': [2],
+      '@scope-with-dash/scoped-with-dash-plugin/foo-rule': [2],
       '@scope/foo-rule': [2],
       '@scope/scoped-plugin/foo-rule': [2],
       'bar-rule': [2],
@@ -271,6 +299,10 @@ describe('rule-finder', () => {
   it('specifiedFile (relative path) - plugin rules', () => {
     const ruleFinder = getRuleFinder(specifiedFileRelative);
     assertDeepEqual(ruleFinder.getPluginRules(), [
+      '@scope-with-dash/bar-rule',
+      '@scope-with-dash/foo-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/bar-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/foo-rule',
       '@scope/bar-rule',
       '@scope/foo-rule',
       '@scope/scoped-plugin/bar-rule',
@@ -284,6 +316,12 @@ describe('rule-finder', () => {
   it('specifiedFile (relative path) - plugin rules including deprecated', () => {
     const ruleFinder = getRuleFinder(specifiedFileRelative, {includeDeprecated: true});
     assertDeepEqual(ruleFinder.getPluginRules(), [
+      '@scope-with-dash/bar-rule',
+      '@scope-with-dash/foo-rule',
+      '@scope-with-dash/old-plugin-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/bar-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/foo-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/old-plugin-rule',
       '@scope/bar-rule',
       '@scope/foo-rule',
       '@scope/old-plugin-rule',
@@ -302,6 +340,10 @@ describe('rule-finder', () => {
     assertDeepEqual(
       ruleFinder.getAllAvailableRules(),
       [
+        '@scope-with-dash/bar-rule',
+        '@scope-with-dash/foo-rule',
+        '@scope-with-dash/scoped-with-dash-plugin/bar-rule',
+        '@scope-with-dash/scoped-with-dash-plugin/foo-rule',
         '@scope/bar-rule',
         '@scope/foo-rule',
         '@scope/scoped-plugin/bar-rule',
@@ -321,6 +363,10 @@ describe('rule-finder', () => {
     assertDeepEqual(
       ruleFinder.getAllAvailableRules(),
       [
+        '@scope-with-dash/bar-rule',
+        '@scope-with-dash/foo-rule',
+        '@scope-with-dash/scoped-with-dash-plugin/bar-rule',
+        '@scope-with-dash/scoped-with-dash-plugin/foo-rule',
         '@scope/bar-rule',
         '@scope/foo-rule',
         '@scope/scoped-plugin/bar-rule',
@@ -337,6 +383,12 @@ describe('rule-finder', () => {
     assertDeepEqual(
       ruleFinder.getAllAvailableRules(),
       [
+        '@scope-with-dash/bar-rule',
+        '@scope-with-dash/foo-rule',
+        '@scope-with-dash/old-plugin-rule',
+        '@scope-with-dash/scoped-with-dash-plugin/bar-rule',
+        '@scope-with-dash/scoped-with-dash-plugin/foo-rule',
+        '@scope-with-dash/scoped-with-dash-plugin/old-plugin-rule',
         '@scope/bar-rule',
         '@scope/foo-rule',
         '@scope/old-plugin-rule',
@@ -358,6 +410,8 @@ describe('rule-finder', () => {
   it('specifiedFile (absolute path) - unused rules', () => {
     const ruleFinder = getRuleFinder(specifiedFileAbsolute);
     assertDeepEqual(ruleFinder.getUnusedRules(), [
+      '@scope-with-dash/bar-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/bar-rule',
       '@scope/bar-rule',
       '@scope/scoped-plugin/bar-rule',
       'baz-rule',
@@ -370,6 +424,10 @@ describe('rule-finder', () => {
   it('specifiedFile (absolute path) - unused rules', () => {
     const ruleFinder = getRuleFinder(specifiedFileAbsolute, {includeDeprecated: true});
     assertDeepEqual(ruleFinder.getUnusedRules(), [
+      '@scope-with-dash/bar-rule',
+      '@scope-with-dash/old-plugin-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/bar-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/old-plugin-rule',
       '@scope/bar-rule',
       '@scope/old-plugin-rule',
       '@scope/scoped-plugin/bar-rule',
@@ -386,6 +444,8 @@ describe('rule-finder', () => {
   it('specifiedFile (absolute path) - current rules', () => {
     const ruleFinder = getRuleFinder(specifiedFileAbsolute);
     assertDeepEqual(ruleFinder.getCurrentRules(), [
+      '@scope-with-dash/foo-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/foo-rule',
       '@scope/foo-rule',
       '@scope/scoped-plugin/foo-rule',
       'bar-rule',
@@ -396,6 +456,8 @@ describe('rule-finder', () => {
   it('specifiedFile (absolute path) - current rule config', () => {
     const ruleFinder = getRuleFinder(specifiedFileAbsolute);
     assertDeepEqual(ruleFinder.getCurrentRulesDetailed(), {
+      '@scope-with-dash/foo-rule': [2],
+      '@scope-with-dash/scoped-with-dash-plugin/foo-rule': [2],
       '@scope/foo-rule': [2],
       '@scope/scoped-plugin/foo-rule': [2],
       'foo-rule': [2],
@@ -406,6 +468,10 @@ describe('rule-finder', () => {
   it('specifiedFile (absolute path) - plugin rules', () => {
     const ruleFinder = getRuleFinder(specifiedFileAbsolute);
     assertDeepEqual(ruleFinder.getPluginRules(), [
+      '@scope-with-dash/bar-rule',
+      '@scope-with-dash/foo-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/bar-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/foo-rule',
       '@scope/bar-rule',
       '@scope/foo-rule',
       '@scope/scoped-plugin/bar-rule',
@@ -419,6 +485,12 @@ describe('rule-finder', () => {
   it('specifiedFile (absolute path) - plugin rules including deprecated', () => {
     const ruleFinder = getRuleFinder(specifiedFileAbsolute, {includeDeprecated: true});
     assertDeepEqual(ruleFinder.getPluginRules(), [
+      '@scope-with-dash/bar-rule',
+      '@scope-with-dash/foo-rule',
+      '@scope-with-dash/old-plugin-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/bar-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/foo-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/old-plugin-rule',
       '@scope/bar-rule',
       '@scope/foo-rule',
       '@scope/old-plugin-rule',
@@ -437,6 +509,10 @@ describe('rule-finder', () => {
     assertDeepEqual(
       ruleFinder.getAllAvailableRules(),
       [
+        '@scope-with-dash/bar-rule',
+        '@scope-with-dash/foo-rule',
+        '@scope-with-dash/scoped-with-dash-plugin/bar-rule',
+        '@scope-with-dash/scoped-with-dash-plugin/foo-rule',
         '@scope/bar-rule',
         '@scope/foo-rule',
         '@scope/scoped-plugin/bar-rule',
@@ -456,6 +532,12 @@ describe('rule-finder', () => {
     assertDeepEqual(
       ruleFinder.getAllAvailableRules(),
       [
+        '@scope-with-dash/bar-rule',
+        '@scope-with-dash/foo-rule',
+        '@scope-with-dash/old-plugin-rule',
+        '@scope-with-dash/scoped-with-dash-plugin/bar-rule',
+        '@scope-with-dash/scoped-with-dash-plugin/foo-rule',
+        '@scope-with-dash/scoped-with-dash-plugin/old-plugin-rule',
         '@scope/bar-rule',
         '@scope/foo-rule',
         '@scope/old-plugin-rule',
@@ -509,6 +591,8 @@ describe('rule-finder', () => {
   it('specifiedFile (absolute path) with deprecated rules - deprecated rules', () => {
     const ruleFinder = getRuleFinder(usingDeprecatedRulesFile);
     assertDeepEqual(ruleFinder.getDeprecatedRules(), [
+      '@scope-with-dash/old-plugin-rule',
+      '@scope-with-dash/scoped-with-dash-plugin/old-plugin-rule',
       '@scope/old-plugin-rule',
       '@scope/scoped-plugin/old-plugin-rule',
       'old-rule',

--- a/test/lib/rule-finder.js
+++ b/test/lib/rule-finder.js
@@ -36,7 +36,7 @@ const getRuleFinder = proxyquire('../../src/lib/rule-finder', {
   },
   //
   // This following module override is needed for eslint v6 and over. The module
-  // path that we pass here is literally the one used in eslint (specifially in
+  // path that we pass here is literally the one used in eslint (specifically in
   // eslint/lib/cli-engine/config-array-factory.js)
   //
   // The stock `resolve` method attempts to resolve to a file path the module
@@ -49,12 +49,16 @@ const getRuleFinder = proxyquire('../../src/lib/rule-finder', {
       // the module name, as-is. This is a lie because what we return is not a
       // path, but it is simple, and works. Otherwise, we just call the original
       // `resolve` from the stock module.
-      return ['eslint-plugin-plugin',
+      return [
+        'eslint-plugin-plugin',
         'eslint-plugin-no-rules',
         '@scope/eslint-plugin-scoped-plugin',
-        '@scope/eslint-plugin'].includes(name) ?
-        name :
-        ModuleResolver.resolve(name, relative);
+        '@scope/eslint-plugin',
+        '@scope-with-dash/eslint-plugin-scoped-with-dash-plugin',
+        '@scope-with-dash/eslint-plugin'
+      ].includes(name) ?
+          name :
+          ModuleResolver.resolve(name, relative);
     },
     '@global': true,
     '@noCallThru': true


### PR DESCRIPTION
Use eslint's internal functions to support shorthand eslint plugin naming.

fix #303