### PR TITLE
fix(rule-finder): pass a file to getConfigForFile

### DIFF
--- a/src/lib/rule-finder.js
+++ b/src/lib/rule-finder.js
@@ -23,7 +23,7 @@ function _getConfig(configFile) {
     // Point to the particular config
     configFile
   });
-  return cliEngine.getConfigForFile();
+  return cliEngine.getConfigForFile(configFile);
 }
 
 function _getCurrentNamesRules(config) {


### PR DESCRIPTION
This fixes a compatibility issue with eslint@6 which now passes the given file to `path.resolve` (https://github.com/eslint/eslint/blob/1fb362093a65b99456a11029967d9ee0c31fd697/lib/cli-engine/cli-engine.js#L905) which will throw if no file is given.

I tried this locally and it works without issue.