### PR TITLE
chore: upgrade `yargs` to latest version

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -110,6 +110,16 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "sturdynut",
+      "name": "Matti Salokangas",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/8547391?v=4",
+      "profile": "https://sturdynut.com",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "repoType": "github"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "path-is-absolute": "^1.0.1",
     "which": "^1.2.8",
     "window-size": "0.3.0",
-    "yargs": "^8.0.1"
+    "yargs": "^14.2.0"
   },
   "devDependencies": {
     "ajv": "^5 || ^6",


### PR DESCRIPTION
This change should fix a security vulnerability (_mem v^1.1.0_) from the version of `yargs` used by this project.  Here is the warning we are getting from our repo that uses `eslint-find-rules`:

![image](https://user-images.githubusercontent.com/8547391/67150040-5732a180-f267-11e9-89a6-c3b9df27b1b3.png)

Here's the chain of dependencies that lead to the insecure package.

* eslint-find-rules  → yargs (v8.0.1)
* yargs (v8.0.1) → os-locale (v2.0.0)
* os-locale (v2.0.0) → mem (v^1.1.0")

I ran tests after upgrading and seemed ok, however there are quite a few breaking changes between yargs v8.0.1 and the current v14.2.0, so i've listed them below for your reference.

### Breaking Changes 

_since v8.0.1_

* we now only officially support yargs.$0 parameter and discourage direct access to yargs.parsed
* previously to this fix methods like yargs.getOptions() contained the state of the last command to execute.
* do not allow additional positionals in strict mode
* options with leading '+' or '0' now parse as strings
* dropping Node 6 which hits end of life in April 2019
* see yargs-parser@12.0.0 CHANGELOG
* we now warn if the yargs stanza package.json is used.
* Options absent from argv (not set via CLI argument) are now absent from the parsed result object rather than being set with undefined
* drop Node 4 from testing matrix, such that we'll gradually start drifting away from supporting Node 4.
* yargs-parser does not populate 'false' when boolean flag is not passed
* tests that assert against help output will need to be updated
* requiresArg now has significantly different error output, matching nargs.
* .usage() no longer accepts an options object as the second argument. It can instead be used as an * alias for configuring a default command.
previously hidden options were simply implied using a falsy description
* help command now only executes if it's the last positional in argv._
* version() and help() are now enabled by default, and show up in help output; the implicit help command can no longer be enabled/disabled independently from the help command itself (which can now be disabled).
* parse() now behaves as an alias for .argv, unless a parseCallback is provided.