### PR TITLE
fix: ESLint 7.8.0 removes normalization function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
   include:
     - node_js: "node"
       env: LINTONLY=true
+    - node_js: "14"
+      env: ESLINT=7.7
     - node_js: "8"
       env: ESLINT=6
     - node_js: "8"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@eslint/eslintrc": "^0.1.0",
     "cliui": "^3.2.0",
     "eslint-rule-documentation": "^1.0.0",
     "glob": "^7.1.4",

--- a/src/lib/normalize-plugin-name.js
+++ b/src/lib/normalize-plugin-name.js
@@ -8,6 +8,25 @@ function _getNormalizer() {
   }
 
   const eslintVersionFunctions = [
+    // eslint >= 7.0.0
+    function () {
+      const ESLintExports = require('eslint');
+
+      const version = ESLintExports.ESLint.version;
+
+      if (!version) {
+        throw new Error('Unable to find eslint version');
+      }
+
+      const ESLintRC = require('@eslint/eslintrc');
+
+      const naming = ESLintRC.Legacy.naming;
+
+      return {
+        normalizePackageName: naming.normalizePackageName,
+        getShorthandName: naming.getShorthandName
+      }
+    },
     // eslint >= 6.1.0
     function () {
       const normalizer = require('eslint/lib/shared/naming');


### PR DESCRIPTION
Issue #331

ESLint 7.8.0 removed the normalization functions this package used for package/plugin naming. The naming functions have now been moved into @eslint/eslintrc package. This change includes eslintrc as a dependency and removes the old logic of finding the function in the eslint source code.