### PR TITLE
chore: update babel and eslint to support es2017

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,10 @@
 {
-  "presets": ["es2015"]
+  "presets": [
+    ["env", {
+      "targets": {
+        "node": "4"
+      },
+      "exclude": ["transform-regenerator"]
+    }]
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,7 @@
     "ecmaFeatures": {
       "impliedStrict": true
     },
-    "ecmaVersion": 2015
+    "ecmaVersion": 2017
   },
   "plugins": ["json"],
   "root": true

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "aud": "^1.1.5",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.7.0",
     "codecov": "^2.3.1",
     "commitizen": "^2.10.1",
     "cz-conventional-changelog": "^2.1.0",


### PR DESCRIPTION
Resolve https://github.com/MichaelDeBoey/eslint-find-rules/pull/13#discussion_r744166294

* Switch to use `babel-preset-env`, since `babel-preset-es2015` has been deprecated and the former supports es2017 and more configurations
* Exclude `transform-regenerator` in babel config since `transform-regenerator` requires a runtime polyfill and isn't actually needed if we don't use [`Generator.prototype.return()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/return)
* Update eslint target ecma version to 2017