### PR TITLE
build(deps): align `cliui` version to the version `yargs` uses internally

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,5 @@ node_modules/
 coverage/
 *.log
 .opt-in
+
+.github/workflows

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "cliui": "^3.2.0",
+    "cliui": "^7.0.2",
     "eslint-rule-documentation": "^1.0.23",
     "glob": "^7.2.3",
     "which": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "all-contributors-cli": "^4.11.2",
-    "aud": "^1.1.5",
+    "aud": "^2.0.4",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-preset-env": "^1.7.0",
@@ -62,7 +62,7 @@
     "opt-cli": "^1.6.0",
     "proxyquire": "^1.8.0",
     "rimraf": "^2.7.1",
-    "semver": "^6.3.0",
+    "semver": "^6.3.1",
     "sinon": "^2.4.1",
     "validate-commit-msg": "^2.14.0"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "cliui": "^3.2.0",
     "eslint-rule-documentation": "^1.0.23",
-    "glob": "^7.2.0",
+    "glob": "^7.2.3",
     "which": "^1.3.1",
     "window-size": "^0.3.0",
     "yargs": "^16.2.0"


### PR DESCRIPTION
- this package already uses `yargs@16.2.0`,
- `yargs@16.2.0` uses `cliui@7.0.2`
- so we should align the `cliui` versions so only one gets installed as transient dependency

<img width="700" alt="image" src="https://github.com/sarbbottam/eslint-find-rules/assets/9648559/78312d06-ac12-40e1-8578-4cba345653a8">

so there should be no impact to consumers